### PR TITLE
fix: allowlist mock workload access token in gitleaks config

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -10,3 +10,7 @@ paths = [
     "^agent/tests/test_hooks\\.py$",
     "^agent/tests/test_output_scanner\\.py$",
 ]
+
+[[allowlists]]
+description = "Mock workload access token in CDK handler tests (not a real credential)."
+stopwords = ["wat-opaque-123"]


### PR DESCRIPTION
## Summary
- Add gitleaks allowlist entry for `context-hydration.test.ts` to suppress false positive on mock workload access token (`wat-opaque-123`)
- The `generic-api-key` rule flags this test fixture value across all git history, blocking every `git push` via the pre-push security hook

## Context
The mock token was introduced in commit `d402a681` and triggers gitleaks on every push, even though it is not a real credential. The existing `.gitleaks.toml` already has a similar allowlist for PEM fixtures in agent tests — this follows the same pattern.

## Test plan
- [x] `gitleaks detect --source . --no-banner` reports `no leaks found` after the change
- [ ] Pre-push hook `security:secrets` stage passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)