### PR TITLE
fix: increase custom aws timeout to 5 minutes

### DIFF
--- a/cdk/src/constructs/blueprint.ts
+++ b/cdk/src/constructs/blueprint.ts
@@ -194,7 +194,6 @@ export class Blueprint extends Construct {
     }
 
     new cr.AwsCustomResource(this, 'RepoConfigCR', {
-      installLatestAwsSdk: false,
       timeout: Duration.minutes(5),
       onCreate: {
         service: 'DynamoDB',

--- a/cdk/src/constructs/blueprint.ts
+++ b/cdk/src/constructs/blueprint.ts
@@ -17,6 +17,7 @@
  *  SOFTWARE.
  */
 
+import { Duration } from 'aws-cdk-lib';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as cr from 'aws-cdk-lib/custom-resources';
@@ -193,6 +194,8 @@ export class Blueprint extends Construct {
     }
 
     new cr.AwsCustomResource(this, 'RepoConfigCR', {
+      installLatestAwsSdk: false,
+      timeout: Duration.minutes(5),
       onCreate: {
         service: 'DynamoDB',
         action: 'putItem',


### PR DESCRIPTION
<!-- Summarize the pull request -->
  Based on the timing analysis:

  ```table
┌───────────────────────────────────┬──────────┬───────────┬──────────────────────────┐
  │ Resource                          │ Started  │ Completed │ Duration                 │
  ├───────────────────────────────────┼──────────┼───────────┼──────────────────────────┤
  │ DnsFirewallConfig                 │ 22:02:49 │ 22:04:29  │ ~100s ✅                 │
  ├───────────────────────────────────┼──────────┼───────────┼──────────────────────────┤
  │ ModelInvocationLogging            │ 22:02:49 │ 22:04:29  │ ~100s ✅                 │
  ├───────────────────────────────────┼──────────┼───────────┼──────────────────────────┤
  │ AgentPluginsBlueprintRepoConfigCR │ 22:02:49 │ 23:03:03  │ ~60 min ❌ (CFN timeout) │
  └───────────────────────────────────┴──────────┴───────────┴──────────────────────────┘
```

  The Lambda for the Blueprint ran for 85 seconds (log stream shows activity from 22:02:50 to 22:04:15), the DynamoDB PutItem succeeded, but the Lambda failed to send the cfn-response callback back to CloudFormation's pre-signed S3 URL. After the Lambda finished (or timed out), CloudFormation waited the full 1-hour custom resource timeout before declaring failure.

  The most likely explanation: the AwsCustomResource framework handler's HTTP PUT to the CloudFormation response URL was blocked or timed out. Since InstallLatestAwsSdk is "true", the Lambda spends time installing the latest SDK via npm at cold start — this eats into the Lambda timeout. If the Lambda's execution timeout (default 2 min for AwsCustomResource) was hit after the DynamoDB call succeeded but before the response URL callback completed, you'd see exactly this behavior.

  The 85-second log duration supports this — the SDK install + DynamoDB call consumed most of the Lambda timeout, leaving insufficient time for the cfn-response HTTP callback, or the Lambda timed out during it.

  The fix: In cdk/src/constructs/blueprint.ts, set installLatestAwsSdk: false (it's deprecated and unnecessary with SDK v3 bundled in the Lambda runtime) and increase the timeout:

```typescript
  new cr.AwsCustomResource(this, 'RepoConfigCR', {
    timeout: Duration.minutes(5),  // Give more headroom
    onCreate: { /* ... */ },
    // ...
  });
```

#### Area

<!-- Check all that apply -->

- [x] `cdk` — infrastructure, handlers, constructs
- [ ] `agent` — Python runtime / Docker image
- [ ] `cli` — `bgagent` client
- [ ] `docs` — guides or design sources (`docs/guides/`, `docs/design/`)
- [ ] `tooling` — root `mise.toml`, scripts, CI workflows

Tip: [AGENTS.md](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/blob/main/AGENTS.md) lists where to edit and which tests to extend.

#### Related

<!-- Issue #, Vulnerability, References if available:* -->

#### Changes

<!-- Description of changes:* -->

Increased the timeout.

#### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/blob/main/LICENSE).
