### PR TITLE
chore(docs): add git worktree guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Handler entry tests: `cdk/test/handlers/orchestrate-task.test.ts`, `create-task.
 - **`MISE_EXPERIMENTAL=1`** — required for namespaced tasks like **`mise //cdk:build`** (see [CONTRIBUTING.md](./CONTRIBUTING.md)).
 - **`mise run build`** runs **`//agent:quality`** before CDK — the deployed image bundles **`agent/`**; agent changes belong in that tree.
 - **`prek install`** fails if Git **`core.hooksPath`** is set — another hook manager owns hooks; see [CONTRIBUTING.md](./CONTRIBUTING.md).
+- **Git worktrees** — `node_modules/` and `agent/.venv/` are per-tree (not shared). Run **`mise run install`** in each new worktree before building. All CDK path references (`__dirname`-relative) and mise `config_roots` resolve correctly without extra setup.
 
 ### Tech stack
 


### PR DESCRIPTION
## Summary
- Documents that `node_modules/` and `agent/.venv/` are per-worktree and require `mise run install` in each new worktree
- Confirms CDK path references (`__dirname`-relative) and mise `config_roots` resolve correctly without extra setup
- Added as a bullet in the existing "Common mistakes" section for discoverability

## Test plan
- [x] Verify AGENTS.md renders correctly on GitHub
- [x] Confirm no docs sync required (change is in AGENTS.md, not `docs/guides/` or `docs/design/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)