### PR TITLE
fix(security): redact clear-text logging of sensitive information

### DIFF
--- a/agent/src/server.py
+++ b/agent/src/server.py
@@ -12,6 +12,7 @@ import asyncio
 import contextlib as _ctx_for_debug
 import logging
 import os
+import re
 import threading
 import time as _time_for_debug
 import traceback
@@ -31,12 +32,27 @@ from pipeline import run_task
 
 
 def _redact_cached_credentials(text: str) -> str:
-    """Remove cached env secrets from debug text before stdout / CloudWatch."""
+    """Remove sensitive material from debug text before stdout / CloudWatch."""
     out = text
+
+    # 1) Redact exact cached secret values when present.
     for env_key in ("GITHUB_TOKEN", "LINEAR_API_TOKEN"):
         secret = os.environ.get(env_key) or ""
         if len(secret) >= 12:
             out = out.replace(secret, f"<{env_key}_REDACTED>")
+
+    # 2) Redact common secret-bearing key/value patterns.
+    secret_patterns = (
+        r"(?i)\b(github_token|linear_api_token|token|secret|api[_-]?key|password)\b\s*[:=]\s*([^\s,;]+)",
+        r"(?i)\b(authorization)\b\s*[:=]\s*(bearer\s+)?([^\s,;]+)",
+    )
+    for pattern in secret_patterns:
+        out = re.sub(
+            pattern,
+            lambda m: f"{m.group(1)}=<REDACTED>",
+            out,
+        )
+
     return out
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/security/code-scanning/24](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/security/code-scanning/24)

Best fix: harden `_debug_cw` so it never logs raw free-form text; instead, apply stronger sanitization that masks known secret values and secret-like key/value patterns before printing or shipping to CloudWatch.

Concretely in `agent/src/server.py`:
- Add `import re`.
- Replace `_redact_cached_credentials` implementation with a stronger sanitizer that:
  1. Redacts cached env secret values (`GITHUB_TOKEN`, `LINEAR_API_TOKEN`) when present.
  2. Redacts common secret assignment patterns in text (e.g., `github_token=...`, `authorization: Bearer ...`, `secret=...`, `token=...`, `api_key=...`, `password=...`) using regex.
- Keep behavior unchanged otherwise (same function name and call sites), so logging still works but sensitive values are masked.

No functional flow changes are required; only log content sanitization is strengthened.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
