### PR TITLE
feat(cdk): add github:* resource tagging strategy

### DIFF
--- a/cdk/src/main.ts
+++ b/cdk/src/main.ts
@@ -17,7 +17,7 @@
  *  SOFTWARE.
  */
 
-import { App, Aspects } from 'aws-cdk-lib';
+import { App, Aspects, Tags } from 'aws-cdk-lib';
 import { AwsSolutionsChecks } from 'cdk-nag';
 import { AgentStack } from './stacks/agent';
 
@@ -33,7 +33,7 @@ Aspects.of(app).add(new AwsSolutionsChecks());
 
 const stackName = app.node.tryGetContext('stackName') ?? 'backgroundagent-dev';
 
-new AgentStack(
+const stack = new AgentStack(
   app,
   stackName,
   {
@@ -41,5 +41,22 @@ new AgentStack(
     description: 'ABCA Development Stack',
   },
 );
+
+const githubTagKeys = [
+  'sha',
+  'ref',
+  'ref-type',
+  'actor',
+  'head-ref',
+  'run-id',
+  'event',
+  'repository',
+  'clean',
+] as const;
+
+for (const key of githubTagKeys) {
+  const value = app.node.tryGetContext(`github:${key}`);
+  Tags.of(stack).add(`github:${key}`, value || 'none');
+}
 
 app.synth();

--- a/cdk/test/stacks/github-tags.test.ts
+++ b/cdk/test/stacks/github-tags.test.ts
@@ -1,0 +1,115 @@
+/**
+ *  MIT No Attribution
+ *
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy of
+ *  the Software without restriction, including without limitation the rights to
+ *  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ *  the Software, and to permit persons to whom the Software is furnished to do so.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+import { App, Tags } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { AgentStack } from '../../src/stacks/agent';
+
+const GITHUB_TAG_KEYS = [
+  'github:sha',
+  'github:ref',
+  'github:ref-type',
+  'github:actor',
+  'github:head-ref',
+  'github:run-id',
+  'github:event',
+  'github:repository',
+  'github:clean',
+] as const;
+
+function synthWithTags(context: Record<string, string> = {}): Template {
+  const app = new App({ context });
+  const stackName = app.node.tryGetContext('stackName') ?? 'backgroundagent-dev';
+  const stack = new AgentStack(app, stackName, {
+    env: { account: '123456789012', region: 'us-east-1' },
+  });
+
+  const githubTagKeys = [
+    'sha', 'ref', 'ref-type', 'actor', 'head-ref',
+    'run-id', 'event', 'repository', 'clean',
+  ] as const;
+
+  for (const key of githubTagKeys) {
+    const value = app.node.tryGetContext(`github:${key}`);
+    Tags.of(stack).add(`github:${key}`, value || 'none');
+  }
+
+  return Template.fromStack(stack);
+}
+
+describe('github:* resource tags', () => {
+  let templateWithDefaults: Template;
+  let templateWithValues: Template;
+
+  beforeAll(() => {
+    templateWithDefaults = synthWithTags();
+    templateWithValues = synthWithTags({
+      'github:sha': 'f36d352c5a1bc3a90d3e60e30e2f9d4345426724',
+      'github:ref': 'main',
+      'github:ref-type': 'branch',
+      'github:actor': 'scottschreckengaust',
+      'github:head-ref': '',
+      'github:run-id': '12345678',
+      'github:event': 'push',
+      'github:repository': 'aws-samples/sample-autonomous-cloud-coding-agents',
+      'github:clean': 'true',
+    });
+  });
+
+  test('all 9 github:* tags default to "none" when no context is provided', () => {
+    const resources = templateWithDefaults.findResources('AWS::DynamoDB::Table');
+    const firstResource = Object.values(resources)[0];
+    const tags: Array<{ Key: string; Value: string }> = firstResource?.Properties?.Tags ?? [];
+
+    for (const tagKey of GITHUB_TAG_KEYS) {
+      const tag = tags.find(t => t.Key === tagKey);
+      expect(tag).toBeDefined();
+      expect(tag!.Value).toBe('none');
+    }
+  });
+
+  test('github:* tags reflect context values when provided', () => {
+    const resources = templateWithValues.findResources('AWS::DynamoDB::Table');
+    const firstResource = Object.values(resources)[0];
+    const tags: Array<{ Key: string; Value: string }> = firstResource?.Properties?.Tags ?? [];
+
+    expect(tags.find(t => t.Key === 'github:sha')!.Value).toBe('f36d352c5a1bc3a90d3e60e30e2f9d4345426724');
+    expect(tags.find(t => t.Key === 'github:ref')!.Value).toBe('main');
+    expect(tags.find(t => t.Key === 'github:ref-type')!.Value).toBe('branch');
+    expect(tags.find(t => t.Key === 'github:actor')!.Value).toBe('scottschreckengaust');
+    expect(tags.find(t => t.Key === 'github:head-ref')!.Value).toBe('none');
+    expect(tags.find(t => t.Key === 'github:run-id')!.Value).toBe('12345678');
+    expect(tags.find(t => t.Key === 'github:event')!.Value).toBe('push');
+    expect(tags.find(t => t.Key === 'github:repository')!.Value).toBe('aws-samples/sample-autonomous-cloud-coding-agents');
+    expect(tags.find(t => t.Key === 'github:clean')!.Value).toBe('true');
+  });
+
+  test('empty string context values resolve to "none"', () => {
+    const template = synthWithTags({
+      'github:sha': '',
+      'github:head-ref': '',
+    });
+    const resources = template.findResources('AWS::DynamoDB::Table');
+    const firstResource = Object.values(resources)[0];
+    const tags: Array<{ Key: string; Value: string }> = firstResource?.Properties?.Tags ?? [];
+
+    expect(tags.find(t => t.Key === 'github:sha')!.Value).toBe('none');
+    expect(tags.find(t => t.Key === 'github:head-ref')!.Value).toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary

- Applies 9 `github:*` tags to all stack resources via `Tags.of(stack).add()` in `main.ts`
- Tags are injected through CDK context (`-c github:sha=...`, etc.) and default to sentinel `none`
- Ensures consistent tag schema across all stacks for cleanup harvesting and CI/CD provenance

Closes #84

## Tags

| Tag key | CI variable | `gh` / `git` CLI | Default |
|---------|------------|-------------------|---------|
| `github:sha` | `$GITHUB_SHA` | `gh api /repos/{owner}/{repo}/commits/{ref} --jq .sha` / `git rev-parse HEAD` | `none` |
| `github:ref` | `$GITHUB_REF_NAME` | `gh api /repos/{owner}/{repo}/git/ref/heads/{branch} --jq .ref` / `git branch --show-current` | `none` |
| `github:ref-type` | `$GITHUB_REF_TYPE` | `gh api /repos/{owner}/{repo}/git/ref/heads/{branch}` → `branch` or `/tags/{tag}` → `tag` / `git cat-file -t $(git rev-parse HEAD)` | `none` |
| `github:actor` | `$GITHUB_ACTOR` | `gh api /user --jq .login` / `git config user.name` | `none` |
| `github:head-ref` | `$GITHUB_HEAD_REF` | `gh pr view --json headRefName --jq .headRefName` / `none` (only in PR context) | `none` |
| `github:run-id` | `$GITHUB_RUN_ID` | `gh run list --limit 1 --json databaseId --jq '.[0].databaseId'` / N/A (CI only) | `none` |
| `github:event` | `$GITHUB_EVENT_NAME` | `gh run view {run-id} --json event --jq .event` / N/A (CI only) | `none` |
| `github:repository` | `$GITHUB_REPOSITORY` | `gh repo view --json nameWithOwner --jq .nameWithOwner` / `git remote get-url origin` | `none` |
| `github:clean` | `true` (CI always clean) | N/A / `[ -z "$(git status --porcelain)" ] && echo true \|\| echo false` | `none` |

## Test plan

- [x] 3 new tests in `cdk/test/stacks/github-tags.test.ts`
  - All 9 tags default to `none` when no context provided
  - Tags reflect context values when provided
  - Empty string values resolve to `none`
- [x] All 38 existing `agent.test.ts` tests pass unchanged
- [x] TypeScript compiles cleanly


🤖 Generated with [Claude Code](https://claude.com/claude-code)