### PR TITLE
feat(ci): synth-per-variant build with github:* context in artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,14 +56,11 @@ jobs:
         run: mise run install
       - name: build
         run: mise run build
-      - name: CDK Synth (${{ matrix.variant }})
-        run: npx cdk synth -c computeVariant=${{ matrix.variant }} --output cdk-${{ matrix.variant }}.out
-        working-directory: cdk
       - name: Upload CDK artifact (${{ matrix.variant }})
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cdk-${{ matrix.variant }}-out
-          path: cdk/cdk-${{ matrix.variant }}.out/
+          path: cdk/cdk.out/
       - name: Find mutations
         id: self_mutation
         run: |-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
       actions: write # upload-artifact when self-mutation is detected
       contents: read
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        variant: [agentcore]
     outputs:
       self_mutation_happened: ${{ steps.self_mutation.outputs.self_mutation_happened }}
     env:
@@ -53,11 +56,20 @@ jobs:
         run: mise run install
       - name: build
         run: mise run build
+      - name: CDK Synth (${{ matrix.variant }})
+        run: npx cdk synth -c computeVariant=${{ matrix.variant }} --output cdk-${{ matrix.variant }}.out
+        working-directory: cdk
+      - name: Upload CDK artifact (${{ matrix.variant }})
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cdk-${{ matrix.variant }}-out
+          path: cdk/cdk-${{ matrix.variant }}.out/
+          retention-days: 5
       - name: Find mutations
         id: self_mutation
         run: |-
           git add .
-          git diff --staged --patch --exit-code > repo.patch || echo "self_mutation_happened=true" >> $GITHUB_OUTPUT
+          git diff --staged --patch --exit-code -- . ':!cdk/cdk-*.out' > repo.patch || echo "self_mutation_happened=true" >> $GITHUB_OUTPUT
         shell: bash
         working-directory: ./
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cdk-${{ matrix.variant }}-out
-          path: cdk/cdk.out/
+          path: |
+            cdk/cdk.out/
+            cdk/cdk.context.json
       - name: Find mutations
         id: self_mutation
         run: |-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,6 @@ jobs:
       AQUA_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Keep secret and dependency scanning enabled in CI; only disable the
       # remaining tools that are intentionally skipped here.
-      CDK_CONTEXT_computeVariant: ${{ matrix.variant }}
       MISE_DISABLE_TOOLS: "aqua:aquasecurity/trivy,grype,semgrep"
     steps:
       - name: Checkout
@@ -45,6 +44,105 @@ jobs:
         with:
           fetch-depth: 1  # shallow clone
           persist-credentials: false
+      - name: Resolve github:* tag values
+        id: tags
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GH_SHA: ${{ github.sha }}
+          GH_REF_NAME: ${{ github.ref_name }}
+          GH_REF_TYPE: ${{ github.ref_type }}
+          GH_HEAD_REF: ${{ github.head_ref }}
+          GH_BASE_REF: ${{ github.base_ref }}
+          MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          MG_BASE_REF: ${{ github.event.merge_group.base_ref }}
+          MG_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          case "$EVENT_NAME" in
+            merge_group)
+              echo "sha=${MG_HEAD_SHA}" >> "$GITHUB_OUTPUT"
+              echo "ref=${MG_BASE_REF}" >> "$GITHUB_OUTPUT"
+              echo "ref-type=branch" >> "$GITHUB_OUTPUT"
+              echo "head-ref=${MG_HEAD_REF}" >> "$GITHUB_OUTPUT"
+              echo "base-ref=${MG_BASE_REF}" >> "$GITHUB_OUTPUT"
+              PR_NUM=$(echo "$MG_HEAD_REF" | grep -oP 'pr-\K[0-9]+' || echo "")
+              echo "pr-number=${PR_NUM}" >> "$GITHUB_OUTPUT"
+              ;;
+            pull_request|pull_request_target)
+              echo "sha=${PR_HEAD_SHA}" >> "$GITHUB_OUTPUT"
+              echo "ref=${GH_HEAD_REF}" >> "$GITHUB_OUTPUT"
+              echo "ref-type=branch" >> "$GITHUB_OUTPUT"
+              echo "head-ref=${GH_HEAD_REF}" >> "$GITHUB_OUTPUT"
+              echo "base-ref=${GH_BASE_REF}" >> "$GITHUB_OUTPUT"
+              echo "pr-number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+              ;;
+            push)
+              echo "sha=${GH_SHA}" >> "$GITHUB_OUTPUT"
+              echo "ref=${GH_REF_NAME}" >> "$GITHUB_OUTPUT"
+              echo "ref-type=${GH_REF_TYPE}" >> "$GITHUB_OUTPUT"
+              echo "head-ref=" >> "$GITHUB_OUTPUT"
+              echo "base-ref=" >> "$GITHUB_OUTPUT"
+              echo "pr-number=" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "sha=${GH_SHA}" >> "$GITHUB_OUTPUT"
+              echo "ref=${GH_REF_NAME}" >> "$GITHUB_OUTPUT"
+              echo "ref-type=${GH_REF_TYPE}" >> "$GITHUB_OUTPUT"
+              echo "head-ref=" >> "$GITHUB_OUTPUT"
+              echo "base-ref=" >> "$GITHUB_OUTPUT"
+              echo "pr-number=" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+      - name: Generate CDK context
+        env:
+          VARIANT: ${{ matrix.variant }}
+          TAG_SHA: ${{ steps.tags.outputs.sha }}
+          TAG_REF: ${{ steps.tags.outputs.ref }}
+          TAG_REF_TYPE: ${{ steps.tags.outputs.ref-type }}
+          TAG_ACTOR: ${{ github.actor }}
+          TAG_HEAD_REF: ${{ steps.tags.outputs.head-ref }}
+          TAG_BASE_REF: ${{ steps.tags.outputs.base-ref }}
+          TAG_PR_NUMBER: ${{ steps.tags.outputs.pr-number }}
+          TAG_RUN_ID: ${{ github.run_id }}
+          TAG_RUN_ATTEMPT: ${{ github.run_attempt }}
+          TAG_EVENT: ${{ github.event_name }}
+          TAG_WORKFLOW: ${{ github.workflow }}
+          TAG_REPOSITORY: ${{ github.repository }}
+        run: |
+          jq -n \
+            --arg computeVariant "$VARIANT" \
+            --arg stackName "backgroundagent-dev" \
+            --arg sha "$TAG_SHA" \
+            --arg ref "$TAG_REF" \
+            --arg ref_type "$TAG_REF_TYPE" \
+            --arg actor "$TAG_ACTOR" \
+            --arg head_ref "$TAG_HEAD_REF" \
+            --arg base_ref "$TAG_BASE_REF" \
+            --arg pr_number "$TAG_PR_NUMBER" \
+            --arg run_id "$TAG_RUN_ID" \
+            --arg run_attempt "$TAG_RUN_ATTEMPT" \
+            --arg event "$TAG_EVENT" \
+            --arg workflow "$TAG_WORKFLOW" \
+            --arg repository "$TAG_REPOSITORY" \
+            '{
+              "computeVariant": $computeVariant,
+              "stackName": $stackName,
+              "github:sha": $sha,
+              "github:ref": $ref,
+              "github:ref-type": $ref_type,
+              "github:actor": $actor,
+              "github:head-ref": $head_ref,
+              "github:base-ref": $base_ref,
+              "github:pr-number": $pr_number,
+              "github:run-id": $run_id,
+              "github:run-attempt": $run_attempt,
+              "github:event": $event,
+              "github:workflow": $workflow,
+              "github:repository": $repository,
+              "github:clean": "true"
+            }' > cdk/cdk.context.json
+          cat cdk/cdk.context.json
       - name: Install mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,6 @@ jobs:
         with:
           name: cdk-${{ matrix.variant }}-out
           path: cdk/cdk-${{ matrix.variant }}.out/
-          retention-days: 5
       - name: Find mutations
         id: self_mutation
         run: |-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
         id: self_mutation
         run: |-
           git add .
-          git diff --staged --patch --exit-code -- . ':!cdk/cdk-*.out' > repo.patch || echo "self_mutation_happened=true" >> $GITHUB_OUTPUT
+          git diff --staged --patch --exit-code > repo.patch || echo "self_mutation_happened=true" >> $GITHUB_OUTPUT
         shell: bash
         working-directory: ./
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,7 @@ jobs:
       AQUA_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Keep secret and dependency scanning enabled in CI; only disable the
       # remaining tools that are intentionally skipped here.
+      CDK_CONTEXT_computeVariant: ${{ matrix.variant }}
       MISE_DISABLE_TOOLS: "aqua:aquasecurity/trivy,grype,semgrep"
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ agent/.venv/
 # ──────────────────────────────────────────────
 cdk.out/
 /cdk/cdk.out*/
+/cdk/cdk-*.out/
 .cdk.staging/
 cdk.context.json
 /assets/


### PR DESCRIPTION
## Summary

- Adds `strategy.matrix` with `variant: [agentcore]` to the build job
- Generates `cdk/cdk.context.json` before build with all 13 `github:*` tags, `computeVariant`, and `stackName` — CDK reads this automatically during synth, baking tags into CloudFormation templates
- Resolves tag values per event type (`pull_request`, `merge_group`, `push`, `workflow_dispatch`) using intermediate env vars to prevent script injection (CWE-78)
- Uploads `cdk/cdk.out/` + `cdk/cdk.context.json` as immutable artifact (`cdk-<variant>-out`) for downstream `deploy.yml`
- Adds `/cdk/cdk-*.out/` to `.gitignore`

## How it works

```
build.yml:
  Resolve github:* → Generate cdk.context.json → mise run build (synth reads context) → Upload artifact
                                                                                              ↓
deploy.yml (future):                                                     Download artifact → cdk deploy --app cdk.out
```

CDK's `Tags.of(stack).add()` in `main.ts` calls `app.node.tryGetContext('github:sha')` etc. during synthesis. The values come from `cdk.context.json`, so they are baked directly into the template's resource `Tags` arrays. No context flags needed at deploy time.

## Context values generated

| Key | Source (pull_request) | Source (merge_group) | Source (push) |
|-----|----------------------|---------------------|---------------|
| `github:sha` | PR head SHA | merge group head SHA | commit SHA |
| `github:ref` | head branch | base ref (target) | ref name |
| `github:ref-type` | `branch` | `branch` | branch or tag |
| `github:actor` | `github.actor` | `github.actor` | `github.actor` |
| `github:head-ref` | source branch | queue branch | empty |
| `github:base-ref` | target branch | target branch | empty |
| `github:pr-number` | PR number | extracted from queue ref | empty |
| `github:run-id` | `github.run_id` | `github.run_id` | `github.run_id` |
| `github:run-attempt` | `github.run_attempt` | `github.run_attempt` | `github.run_attempt` |
| `github:event` | `github.event_name` | `github.event_name` | `github.event_name` |
| `github:workflow` | `github.workflow` | `github.workflow` | `github.workflow` |
| `github:repository` | `github.repository` | `github.repository` | `github.repository` |
| `github:clean` | `true` | `true` | `true` |

## Local verification

```
$ jq -n '{...}' > cdk/cdk.context.json && cd cdk && npx cdk synth -q
$ jq '[ .. | objects | .Tags? // empty | arrays | .[] | select(.Key? | startswith("github:")) ] | unique_by(.Key)' cdk.out/*.template.json
→ All 13 tags present, 132/299 resources tagged (all taggable resources)
```

## Follow-ups
- Additional variants (`ecs`, `eks`) added to matrix when compute paths are implemented
- `deploy.yml` downloads the artifact and runs `cdk deploy --app cdk.out` — no re-synthesis needed

## Test plan
- [x] CI build passes with matrix strategy (`build (agentcore)`)
- [x] `cdk-agentcore-out` artifact appears in workflow run (contains `cdk.out/` + `cdk.context.json`)
- [x] Mutation check passes (cdk.context.json is gitignored)
- [x] Local synth confirms all 13 `github:*` tags baked into CloudFormation template
- [x] Semgrep passes — no script injection (all GitHub context via `env:` + `jq --arg`)

Refs: #73, #84, #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)