### PR TITLE
feat(cdk): add 4 additional github:* resource tags

### DIFF
--- a/cdk/src/main.ts
+++ b/cdk/src/main.ts
@@ -48,8 +48,12 @@ const githubTagKeys = [
   'ref-type',
   'actor',
   'head-ref',
+  'base-ref',
+  'pr-number',
   'run-id',
+  'run-attempt',
   'event',
+  'workflow',
   'repository',
   'clean',
 ] as const;

--- a/cdk/test/stacks/github-tags.test.ts
+++ b/cdk/test/stacks/github-tags.test.ts
@@ -27,8 +27,12 @@ const GITHUB_TAG_KEYS = [
   'github:ref-type',
   'github:actor',
   'github:head-ref',
+  'github:base-ref',
+  'github:pr-number',
   'github:run-id',
+  'github:run-attempt',
   'github:event',
+  'github:workflow',
   'github:repository',
   'github:clean',
 ] as const;
@@ -42,7 +46,8 @@ function synthWithTags(context: Record<string, string> = {}): Template {
 
   const githubTagKeys = [
     'sha', 'ref', 'ref-type', 'actor', 'head-ref',
-    'run-id', 'event', 'repository', 'clean',
+    'base-ref', 'pr-number', 'run-id', 'run-attempt',
+    'event', 'workflow', 'repository', 'clean',
   ] as const;
 
   for (const key of githubTagKeys) {
@@ -65,14 +70,18 @@ describe('github:* resource tags', () => {
       'github:ref-type': 'branch',
       'github:actor': 'scottschreckengaust',
       'github:head-ref': '',
+      'github:base-ref': 'main',
+      'github:pr-number': '85',
       'github:run-id': '12345678',
+      'github:run-attempt': '1',
       'github:event': 'push',
+      'github:workflow': 'deploy.yml',
       'github:repository': 'aws-samples/sample-autonomous-cloud-coding-agents',
       'github:clean': 'true',
     });
   });
 
-  test('all 9 github:* tags default to "none" when no context is provided', () => {
+  test('all 13 github:* tags default to "none" when no context is provided', () => {
     const resources = templateWithDefaults.findResources('AWS::DynamoDB::Table');
     const firstResource = Object.values(resources)[0];
     const tags: Array<{ Key: string; Value: string }> = firstResource?.Properties?.Tags ?? [];
@@ -94,8 +103,12 @@ describe('github:* resource tags', () => {
     expect(tags.find(t => t.Key === 'github:ref-type')!.Value).toBe('branch');
     expect(tags.find(t => t.Key === 'github:actor')!.Value).toBe('scottschreckengaust');
     expect(tags.find(t => t.Key === 'github:head-ref')!.Value).toBe('none');
+    expect(tags.find(t => t.Key === 'github:base-ref')!.Value).toBe('main');
+    expect(tags.find(t => t.Key === 'github:pr-number')!.Value).toBe('85');
     expect(tags.find(t => t.Key === 'github:run-id')!.Value).toBe('12345678');
+    expect(tags.find(t => t.Key === 'github:run-attempt')!.Value).toBe('1');
     expect(tags.find(t => t.Key === 'github:event')!.Value).toBe('push');
+    expect(tags.find(t => t.Key === 'github:workflow')!.Value).toBe('deploy.yml');
     expect(tags.find(t => t.Key === 'github:repository')!.Value).toBe('aws-samples/sample-autonomous-cloud-coding-agents');
     expect(tags.find(t => t.Key === 'github:clean')!.Value).toBe('true');
   });


### PR DESCRIPTION
## Summary

- Adds 4 new `github:*` tags to complement the 9 tags from #85, bringing the total to 13
- Same pattern: injected via CDK context (`-c github:key=value`), defaulting to `none`
- Tests updated to cover all 13 tags

## New Tags

| Tag key | CI variable | Rationale |
|---------|------------|-----------|
| `github:base-ref` | `${{ github.base_ref }}` / `event.merge_group.base_ref` | Distinguishes deployment target branch from source. Critical for `merge_group` and `pull_request` where `github:ref` is the source, not the target. |
| `github:pr-number` | `${{ github.event.pull_request.number }}` / extracted from merge group ref | Direct trace-back from deployed resource → PR. Simplifies cleanup queries (`aws resourcegroupstaggingapi get-resources --tag-filters Key=github:pr-number`). |
| `github:run-attempt` | `${{ github.run_attempt }}` | Distinguishes retries (same run-id, different attempt). Without this, redeployed resources from a retry look identical to the first attempt. |
| `github:workflow` | `${{ github.workflow }}` | If multiple workflows can deploy (e.g., `deploy.yml` vs `hotfix.yml`), identifies which produced this state. |

## Test plan

- [x] 3 existing tests in `cdk/test/stacks/github-tags.test.ts` updated for all 13 tags
  - All 13 tags default to `none` when no context provided
  - Tags reflect context values when provided (including new tags)
  - Empty string values resolve to `none`
- [x] TypeScript compiles cleanly