### PR TITLE
chore: add worktrees instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ agent/gitleaks-report.json
 # ──────────────────────────────────────────────
 .mcp.json
 .remember/
+.claude/worktrees/
 
 # ──────────────────────────────────────────────
 # Misc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Handler entry tests: `cdk/test/handlers/orchestrate-task.test.ts`, `create-task.
 - **`MISE_EXPERIMENTAL=1`** — required for namespaced tasks like **`mise //cdk:build`** (see [CONTRIBUTING.md](./CONTRIBUTING.md)).
 - **`mise run build`** runs **`//agent:quality`** before CDK — the deployed image bundles **`agent/`**; agent changes belong in that tree.
 - **`prek install`** fails if Git **`core.hooksPath`** is set — another hook manager owns hooks; see [CONTRIBUTING.md](./CONTRIBUTING.md).
+- **Editing on `main` directly** — ALWAYS create a worktree with a feature branch for changes, even trivial ones. Main should stay clean; all work flows through worktree → branch → PR → merge.
 - **Git worktrees** — `node_modules/` and `agent/.venv/` are per-tree (not shared). Run **`mise run install`** in each new worktree before building. All CDK path references (`__dirname`-relative) and mise `config_roots` resolve correctly without extra setup.
 
 ### Tech stack


### PR DESCRIPTION
## Summary
- Adds `.claude/worktrees/` to `.gitignore` to prevent worktree directories from being accidentally staged
- Adds "Editing on `main` directly" to Common mistakes in `AGENTS.md` — instructs all AI assistants to always use worktrees with feature branches, never edit main directly

## Test plan
- [x] `git check-ignore .claude/worktrees/` returns ignored
- [x] `AGENTS.md` Common mistakes section includes worktree-only workflow guidance
- [x] Docs sync produces no mutations (`AGENTS.md` is not mirrored to Starlight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)