### PR TITLE
feat(ci): rename computeVariant to compute_type and apply as resource tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        variant: [agentcore]
+        compute_type: [agentcore]
     outputs:
       self_mutation_happened: ${{ steps.self_mutation.outputs.self_mutation_happened }}
     env:
@@ -96,7 +96,7 @@ jobs:
           esac
       - name: Generate CDK context
         env:
-          VARIANT: ${{ matrix.variant }}
+          COMPUTE_TYPE: ${{ matrix.compute_type }}
           TAG_SHA: ${{ steps.tags.outputs.sha }}
           TAG_REF: ${{ steps.tags.outputs.ref }}
           TAG_REF_TYPE: ${{ steps.tags.outputs.ref-type }}
@@ -111,7 +111,7 @@ jobs:
           TAG_REPOSITORY: ${{ github.repository }}
         run: |
           jq -n \
-            --arg computeVariant "$VARIANT" \
+            --arg compute_type "$COMPUTE_TYPE" \
             --arg stackName "backgroundagent-dev" \
             --arg sha "$TAG_SHA" \
             --arg ref "$TAG_REF" \
@@ -126,7 +126,7 @@ jobs:
             --arg workflow "$TAG_WORKFLOW" \
             --arg repository "$TAG_REPOSITORY" \
             '{
-              "computeVariant": $computeVariant,
+              "compute_type": $compute_type,
               "stackName": $stackName,
               "github:sha": $sha,
               "github:ref": $ref,
@@ -155,10 +155,10 @@ jobs:
         run: mise run install
       - name: build
         run: mise run build
-      - name: Upload CDK artifact (${{ matrix.variant }})
+      - name: Upload CDK artifact (${{ matrix.compute_type }})
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: cdk-${{ matrix.variant }}-out
+          name: cdk-${{ matrix.compute_type }}-out
           path: |
             cdk/cdk.out/
             cdk/cdk.context.json

--- a/cdk/src/main.ts
+++ b/cdk/src/main.ts
@@ -42,6 +42,9 @@ const stack = new AgentStack(
   },
 );
 
+const computeType = app.node.tryGetContext('compute_type') ?? 'agentcore';
+Tags.of(stack).add('compute_type', computeType);
+
 const githubTagKeys = [
   'sha',
   'ref',

--- a/cdk/test/stacks/github-tags.test.ts
+++ b/cdk/test/stacks/github-tags.test.ts
@@ -44,6 +44,9 @@ function synthWithTags(context: Record<string, string> = {}): Template {
     env: { account: '123456789012', region: 'us-east-1' },
   });
 
+  const computeType = app.node.tryGetContext('compute_type') ?? 'agentcore';
+  Tags.of(stack).add('compute_type', computeType);
+
   const githubTagKeys = [
     'sha', 'ref', 'ref-type', 'actor', 'head-ref',
     'base-ref', 'pr-number', 'run-id', 'run-attempt',
@@ -124,5 +127,26 @@ describe('github:* resource tags', () => {
 
     expect(tags.find(t => t.Key === 'github:sha')!.Value).toBe('none');
     expect(tags.find(t => t.Key === 'github:head-ref')!.Value).toBe('none');
+  });
+
+  test('compute_type tag defaults to "agentcore" when no context is provided', () => {
+    const resources = templateWithDefaults.findResources('AWS::DynamoDB::Table');
+    const firstResource = Object.values(resources)[0];
+    const tags: Array<{ Key: string; Value: string }> = firstResource?.Properties?.Tags ?? [];
+
+    const tag = tags.find(t => t.Key === 'compute_type');
+    expect(tag).toBeDefined();
+    expect(tag!.Value).toBe('agentcore');
+  });
+
+  test('compute_type tag reflects context value when provided', () => {
+    const template = synthWithTags({ compute_type: 'ecs' });
+    const resources = template.findResources('AWS::DynamoDB::Table');
+    const firstResource = Object.values(resources)[0];
+    const tags: Array<{ Key: string; Value: string }> = firstResource?.Properties?.Tags ?? [];
+
+    const tag = tags.find(t => t.Key === 'compute_type');
+    expect(tag).toBeDefined();
+    expect(tag!.Value).toBe('ecs');
   });
 });


### PR DESCRIPTION
## Summary

- Renames `computeVariant` → `compute_type` throughout the CI pipeline (`build.yml` matrix key, env var, `cdk.context.json` key) to align with the existing `ComputeType` union type in `repo-config.ts`
- CDK app now reads `compute_type` from context (default: `agentcore`) and applies it as a resource tag via `Tags.of(stack).add('compute_type', computeType)`
- Adds 2 new tests: default value assertion + explicit context value assertion

Closes remaining Phase 2 items in #73.

## What changed

| File | Change |
|------|--------|
| `.github/workflows/build.yml` | `matrix.variant` → `matrix.compute_type`; env `VARIANT` → `COMPUTE_TYPE`; jq arg/key `computeVariant` → `compute_type` |
| `cdk/src/main.ts` | +3 lines: read `compute_type` context, apply as tag |
| `cdk/test/stacks/github-tags.test.ts` | Mirror production logic in helper + 2 new test cases |

## Test plan

- [x] `github-tags.test.ts` — 5/5 pass (3 existing + 2 new)
- [x] TypeScript compiles clean
- [x] Pre-commit hooks pass (eslint, gitleaks, yaml check)
- [ ] CI build passes (will verify artifact name is `cdk-agentcore-out`)

> **Note:** Pre-push security hook has a pre-existing failure (CVE-2026-27135 in `libnghttp2` base image) unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)