### PR TITLE
fix(agent): use uv run for typecheck so env is synced before ty check

### DIFF
--- a/agent/mise.toml
+++ b/agent/mise.toml
@@ -38,7 +38,7 @@ run = "uvx ruff format --check"
 
 [tasks.typecheck]
 description = "Type check with ty"
-run = "uvx ty check"
+run = "uv run ty check"
 
 [tasks.test]
 description = "Run tests with pytest"


### PR DESCRIPTION
<!-- Summarize the pull request -->

#### Area

<!-- Check all that apply -->

- [x] `cdk` — infrastructure, handlers, constructs
- [ ] `agent` — Python runtime / Docker image
- [ ] `cli` — `bgagent` client
- [ ] `docs` — guides or design sources (`docs/guides/`, `docs/design/`)
- [ ] `tooling` — root `mise.toml`, scripts, CI workflows

Tip: [AGENTS.md](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/blob/main/AGENTS.md) lists where to edit and which tests to extend.

#### Related

<!-- Issue #, Vulnerability, References if available:* -->

#### Changes

<!-- Description of changes:* -->

#### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/blob/main/LICENSE).
