### PR TITLE
chore(deps): add Dependabot for actions, docker, pip, and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 
 updates:
-  # GitHub Actions — SHA-pinned actions get digest bumps with tag comments
+  # GitHub Actions — all action bumps in a single PR
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -9,12 +9,12 @@ updates:
       day: "saturday"
     commit-message:
       prefix: "chore(deps)"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
     groups:
-      actions-minor:
-        update-types: ["minor", "patch"]
+      all-actions:
+        patterns: ["*"]
 
-  # Docker — base image tags and digests in agent/Dockerfile
+  # Docker — base image bumps (typically 1-2 images)
   - package-ecosystem: "docker"
     directory: "/agent"
     schedule:
@@ -22,9 +22,12 @@ updates:
       day: "saturday"
     commit-message:
       prefix: "chore(agent)"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 2
+    groups:
+      all-docker:
+        patterns: ["*"]
 
-  # Python (pip/uv) — agent/pyproject.toml and agent/uv.lock
+  # Python (pip/uv) — all Python deps in a single PR
   - package-ecosystem: "pip"
     directory: "/agent"
     schedule:
@@ -32,14 +35,12 @@ updates:
       day: "saturday"
     commit-message:
       prefix: "chore(agent)"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
     groups:
-      opentelemetry:
-        patterns: ["opentelemetry-*"]
-      aws-sdk:
-        patterns: ["boto3", "botocore", "aiobotocore"]
+      all-python:
+        patterns: ["*"]
 
-  # npm — root yarn workspace (cdk, cli, docs)
+  # npm — all JS deps in a single PR (CI catches incompatibilities)
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -47,14 +48,7 @@ updates:
       day: "saturday"
     commit-message:
       prefix: "chore(deps)"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 2
     groups:
-      aws-cdk:
-        patterns: ["aws-cdk-lib", "@aws-cdk/*", "constructs"]
-      eslint:
-        patterns: ["eslint", "eslint-*", "@eslint/*"]
-      jest:
-        patterns: ["jest", "@jest/*", "ts-jest", "@types/jest"]
-      types:
-        patterns: ["@types/*"]
-        update-types: ["minor", "patch"]
+      all-npm:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       interval: "weekly"
       day: "saturday"
     commit-message:
-      prefix: "chore(deps): github-actions"
+      prefix: "chore(deps): actions"
     open-pull-requests-limit: 1
     groups:
       all-actions:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "saturday"
     commit-message:
       prefix: "chore(deps)"
     open-pull-requests-limit: 5
@@ -19,7 +19,7 @@ updates:
     directory: "/agent"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "saturday"
     commit-message:
       prefix: "chore(agent)"
     open-pull-requests-limit: 3
@@ -29,7 +29,7 @@ updates:
     directory: "/agent"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "saturday"
     commit-message:
       prefix: "chore(agent)"
     open-pull-requests-limit: 5
@@ -44,7 +44,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
+      day: "saturday"
     commit-message:
       prefix: "chore(deps)"
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
       all-actions:
         patterns: ["*"]
 
-  # Docker — base image bumps (typically 1-2 images)
+  # Docker — base image bumps (add new entries if Dockerfiles appear elsewhere)
   - package-ecosystem: "docker"
     directory: "/agent"
     schedule:
@@ -27,7 +27,7 @@ updates:
       all-docker:
         patterns: ["*"]
 
-  # Python (pip/uv) — all Python deps in a single PR
+  # Python (pip/uv) — add new entries if pyproject.toml appears elsewhere
   - package-ecosystem: "pip"
     directory: "/agent"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,60 @@
+version: 2
+
+updates:
+  # GitHub Actions — SHA-pinned actions get digest bumps with tag comments
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor:
+        update-types: ["minor", "patch"]
+
+  # Docker — base image tags and digests in agent/Dockerfile
+  - package-ecosystem: "docker"
+    directory: "/agent"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(agent)"
+    open-pull-requests-limit: 3
+
+  # Python (pip/uv) — agent/pyproject.toml and agent/uv.lock
+  - package-ecosystem: "pip"
+    directory: "/agent"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(agent)"
+    open-pull-requests-limit: 5
+    groups:
+      opentelemetry:
+        patterns: ["opentelemetry-*"]
+      aws-sdk:
+        patterns: ["boto3", "botocore", "aiobotocore"]
+
+  # npm — root yarn workspace (cdk, cli, docs)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 10
+    groups:
+      aws-cdk:
+        patterns: ["aws-cdk-lib", "@aws-cdk/*", "constructs"]
+      eslint:
+        patterns: ["eslint", "eslint-*", "@eslint/*"]
+      jest:
+        patterns: ["jest", "@jest/*", "ts-jest", "@types/jest"]
+      types:
+        patterns: ["@types/*"]
+        update-types: ["minor", "patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,6 @@
 version: 2
 
 updates:
-  # GitHub Actions — all action bumps in a single PR
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -14,9 +13,9 @@ updates:
       all-actions:
         patterns: ["*"]
 
-  # Docker — base image bumps (add new entries if Dockerfiles appear elsewhere)
   - package-ecosystem: "docker"
-    directory: "/agent"
+    directories:
+      - "**/*"
     schedule:
       interval: "weekly"
       day: "saturday"
@@ -27,22 +26,22 @@ updates:
       all-docker:
         patterns: ["*"]
 
-  # Python (pip/uv) — add new entries if pyproject.toml appears elsewhere
-  - package-ecosystem: "pip"
-    directory: "/agent"
+  - package-ecosystem: "uv"
+    directories:
+      - "**/*"
     schedule:
       interval: "weekly"
       day: "saturday"
     commit-message:
-      prefix: "chore(deps): pip"
+      prefix: "chore(deps): uv"
     open-pull-requests-limit: 1
     groups:
       all-python:
         patterns: ["*"]
 
-  # npm — all JS deps in a single PR (CI catches incompatibilities)
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "**/*"
     schedule:
       interval: "weekly"
       day: "saturday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,8 @@ updates:
       interval: "weekly"
       day: "saturday"
     commit-message:
-      prefix: "chore(deps)"
-    open-pull-requests-limit: 3
+      prefix: "chore(deps): github-actions"
+    open-pull-requests-limit: 1
     groups:
       all-actions:
         patterns: ["*"]
@@ -21,8 +21,8 @@ updates:
       interval: "weekly"
       day: "saturday"
     commit-message:
-      prefix: "chore(agent)"
-    open-pull-requests-limit: 2
+      prefix: "chore(deps): docker"
+    open-pull-requests-limit: 1
     groups:
       all-docker:
         patterns: ["*"]
@@ -34,8 +34,8 @@ updates:
       interval: "weekly"
       day: "saturday"
     commit-message:
-      prefix: "chore(agent)"
-    open-pull-requests-limit: 2
+      prefix: "chore(deps): pip"
+    open-pull-requests-limit: 1
     groups:
       all-python:
         patterns: ["*"]
@@ -47,8 +47,8 @@ updates:
       interval: "weekly"
       day: "saturday"
     commit-message:
-      prefix: "chore(deps)"
-    open-pull-requests-limit: 2
+      prefix: "chore(deps): npm"
+    open-pull-requests-limit: 1
     groups:
       all-npm:
         patterns: ["*"]


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to enable automated version monitoring across all package ecosystems in this repository.

## Ecosystems configured

| Ecosystem | Discovery | Commit prefix | What it monitors |
|-----------|-----------|---------------|-----------------|
| `github-actions` | `directory: "/"` | `chore(deps): actions` | SHA-pinned action versions in workflows |
| `docker` | `directories: ["**/*"]` | `chore(deps): docker` | `FROM` image tags/digests in any Dockerfile |
| `uv` | `directories: ["**/*"]` | `chore(deps): uv` | `pyproject.toml` + `uv.lock` anywhere in repo |
| `npm` | `directories: ["**/*"]` | `chore(deps): npm` | `package.json` + lockfiles anywhere in repo |

## Key design decisions

- **Schedule:** Weekly on **Saturday** (avoids weekday PR flood; respects UTC→eastern hemisphere dateline)
- **Discovery:** `directories: ["**/*"]` glob auto-discovers manifests — no manual path maintenance when new packages/Dockerfiles are added
- **Grouping:** `patterns: ["*"]` — all updates per ecosystem bundled into a **single PR**
- **PR limit:** 1 per ecosystem (max 4 open Dependabot PRs at any time)
- **Ecosystem:** Uses `uv` (not `pip`) for native `uv.lock` support
- **CI is the quality gate** — bundled updates that break something fail CI

## How it works

- Each Saturday, Dependabot scans the repo for manifests matching each ecosystem
- All available updates for that ecosystem are bundled into one PR
- If last week's PR is still open (not merged), no new PR is created
- If closed without merging, it regenerates the following Saturday
- `@dependabot ignore` suppresses specific deps permanently

## Docker ecosystem behavior

Dependabot detects `FROM` lines in Dockerfiles and bumps:
- Tags (`python:3.13-slim` → `python:3.13.14-slim` when available)
- Digests (`@sha256:abc...` → `@sha256:def...` when upstream rebuilds)

When PR #132 merges (pinning to digest), Dependabot will bump the digest weekly when upstream publishes security patches.

## Test plan

- [x] YAML validates (pre-commit `check yaml` passes)
- [ ] CI passes
- [ ] After merge: verify Dependabot creates initial PRs on next Saturday

## Note on local testing

The `dependabot` CLI binary is installed but requires x86 Docker containers for its proxy — does not currently run on ARM (aarch64) hosts.

Refs #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)