### PR TITLE
fix: add Dependabot cooldown for supply-chain protection

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore(deps): actions"
     open-pull-requests-limit: 1
@@ -19,6 +21,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore(deps): docker"
     open-pull-requests-limit: 1
@@ -32,6 +36,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore(deps): uv"
     open-pull-requests-limit: 1
@@ -45,6 +51,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+    cooldown:
+      default-days: 7
     commit-message:
       prefix: "chore(deps): npm"
     open-pull-requests-limit: 1


### PR DESCRIPTION
## Summary

- Adds `cooldown.default-days: 7` to all 4 Dependabot ecosystem entries (actions, docker, uv, npm)
- Delays auto-ingesting newly-published versions by 7 days, protecting against short-lived supply-chain compromises
- Security updates bypass cooldown entirely — no delay on CVE fixes

## Context

zizmor v1.23+ introduced the `dependabot-cooldown` audit flagging missing cooldown config. This is a real GitHub-native Dependabot feature (not zizmor-invented) that defends against packages that get compromised and yanked within hours.

## Test plan

- [x] `zizmor --offline .github` reports 0 `dependabot-cooldown` findings
- [ ] CI passes

Fixes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)