### PR TITLE
feat(ci): clear disk space on github hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,18 @@ jobs:
       # remaining tools that are intentionally skipped here.
       MISE_DISABLE_TOOLS: "aqua:aquasecurity/trivy,grype,semgrep"
     steps:
+      - name: Free Disk Space
+        shell: bash
+        run: |
+          sudo rm -rf \
+            /usr/local/lib/android \
+            /usr/share/dotnet \
+            /opt/hostedtoolcache \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /usr/local/share/powershell \
+            /usr/share/swift \
+            /usr/lib/jvm || true
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,12 +45,7 @@ jobs:
           sudo rm -rf \
             /usr/local/lib/android \
             /usr/share/dotnet \
-            /opt/hostedtoolcache \
-            /opt/ghc \
-            /usr/local/.ghcup \
-            /usr/local/share/powershell \
-            /usr/share/swift \
-            /usr/lib/jvm || true
+            /opt/hostedtoolcache || true
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Add a step to free disk space before checkout.

<!-- Summarize the pull request -->

#### Area

<!-- Check all that apply -->

- [ ] `cdk` — infrastructure, handlers, constructs
- [ ] `agent` — Python runtime / Docker image
- [ ] `cli` — `bgagent` client
- [ ] `docs` — guides or design sources (`docs/guides/`, `docs/design/`)
- [x] `tooling` — root `mise.toml`, scripts, CI workflows

Tip: [AGENTS.md](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/blob/main/AGENTS.md) lists where to edit and which tests to extend.

#### Related

<!-- Issue #, Vulnerability, References if available:* -->

#### Changes

<!-- Description of changes:* -->

#### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/blob/main/LICENSE).
