### PR TITLE
feat(contracts): migrate approval_timeout_s to contracts/constants.json

### DIFF
--- a/agent/src/hooks.py
+++ b/agent/src/hooks.py
@@ -30,7 +30,7 @@ import nudge_reader
 import task_state
 from nudge_reader import _xml_escape
 from output_scanner import scan_tool_output
-from policy import APPROVAL_RATE_LIMIT, Outcome
+from policy import APPROVAL_RATE_LIMIT, FLOOR_TIMEOUT_S, Outcome
 from progress_writer import _generate_ulid
 from shell import log, log_error_cw
 
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 # Chunk 3 constants (§6.5 pseudocode)
 # ---------------------------------------------------------------------------
 
-FLOOR_30S: int = 30  # §6 decision #6: approval floor on effective timeout
+FLOOR_30S: int = FLOOR_TIMEOUT_S  # §6 decision #6: sourced from contracts/constants.json
 CLEANUP_MARGIN_120S: int = 120  # §6.5 lifetime-margin reserve for cleanup
 # Poll cadence per §3 decision #3 and IMPL-12: 2s for the first 30s, 5s
 # thereafter. Exact counts vary with ``timeout_s``; these pin the

--- a/agent/src/policy.py
+++ b/agent/src/policy.py
@@ -75,9 +75,7 @@ if TYPE_CHECKING:
 # Constants (§3, §5.2, §12.9)
 # ---------------------------------------------------------------------------
 
-FLOOR_TIMEOUT_S: int = 30  # §6 decision #6: rejected below this at load
 WARN_TIMEOUT_S: int = 120  # IMPL-25: sub-120s emits WARN on blueprint load
-DEFAULT_TASK_TIMEOUT_S: int = 300  # §6 decision #6 default
 
 
 def _load_shared_constants() -> dict:
@@ -109,6 +107,9 @@ _AGC = _SHARED_CONSTANTS["approval_gate_cap"]
 DEFAULT_APPROVAL_GATE_CAP: int = int(_AGC["default"])  # decision #13 default
 APPROVAL_GATE_CAP_MIN: int = int(_AGC["min"])
 APPROVAL_GATE_CAP_MAX: int = int(_AGC["max"])
+_ATS = _SHARED_CONSTANTS["approval_timeout_s"]
+FLOOR_TIMEOUT_S: int = int(_ATS["min"])  # §6 decision #6: rejected below this at load
+DEFAULT_TASK_TIMEOUT_S: int = int(_ATS["default"])  # §6 decision #6 default
 CACHE_MAX_ENTRIES: int = 50  # §12.9: decoupled from approvalGateCap
 CACHE_TTL_S: float = 60.0  # §12.8 sliding-window TTL on DENIED/TIMED_OUT
 POLICIES_MAX_BYTES: int = 64 * 1024  # finding #12: reject blueprints > 64 KB

--- a/cdk/src/handlers/shared/types.ts
+++ b/cdk/src/handlers/shared/types.ts
@@ -1022,15 +1022,18 @@ export const INITIAL_APPROVALS_MAX_ENTRIES = 20;
 /** Maximum per-entry length for an `initial_approvals` scope string. */
 export const INITIAL_APPROVALS_MAX_ENTRY_LENGTH = 128;
 
-/** Floor for `approval_timeout_s` (§6 decision #6). */
-export const APPROVAL_TIMEOUT_S_MIN = 30;
+/** Floor for `approval_timeout_s` (§6 decision #6).
+ *  Sourced from ``contracts/constants.json`` (S9). */
+export const APPROVAL_TIMEOUT_S_MIN = sharedConstants.approval_timeout_s.min;
 
 /** Absolute ceiling for `approval_timeout_s` before the
- *  `maxLifetime - 300` clip is applied (§7.3). */
-export const APPROVAL_TIMEOUT_S_MAX = 3600;
+ *  `maxLifetime - 300` clip is applied (§7.3).
+ *  Sourced from ``contracts/constants.json`` (S9). */
+export const APPROVAL_TIMEOUT_S_MAX = sharedConstants.approval_timeout_s.max;
 
-/** Default `approval_timeout_s` when the submit payload omits it. */
-export const APPROVAL_TIMEOUT_S_DEFAULT = 300;
+/** Default `approval_timeout_s` when the submit payload omits it.
+ *  Sourced from ``contracts/constants.json`` (S9). */
+export const APPROVAL_TIMEOUT_S_DEFAULT = sharedConstants.approval_timeout_s.default;
 
 /**
  * Cedar HITL: bounds + platform default for the per-task approval-gate cap

--- a/contracts/constants.json
+++ b/contracts/constants.json
@@ -3,5 +3,10 @@
     "min": 1,
     "max": 500,
     "default": 50
+  },
+  "approval_timeout_s": {
+    "min": 30,
+    "max": 3600,
+    "default": 300
   }
 }

--- a/contracts/constants.md
+++ b/contracts/constants.md
@@ -36,6 +36,11 @@ JSON at TypeScript compile time via `resolveJsonModule`.
     "min": 1,
     "max": 500,
     "default": 50
+  },
+  "approval_timeout_s": {
+    "min": 30,
+    "max": 3600,
+    "default": 300
   }
 }
 ```
@@ -49,6 +54,14 @@ JSON at TypeScript compile time via `resolveJsonModule`.
 - **`approval_gate_cap.default`** — value applied when a blueprint omits
   the field. 50 is the design-decision default (see
   `docs/design/CEDAR_HITL_GATES.md` decision #13).
+- **`approval_timeout_s.min`** — floor for `approval_timeout_s` (§6
+  decision #6). 30 seconds — below this, humans cannot realistically
+  respond to an approval prompt.
+- **`approval_timeout_s.max`** — absolute ceiling for `approval_timeout_s`
+  before the `maxLifetime - 300` clip is applied (§7.3). 3600 seconds
+  (1 hour).
+- **`approval_timeout_s.default`** — value applied when the submit payload
+  omits `approval_timeout_s`. 300 seconds (5 minutes) per §6 decision #6.
 
 ## Adding new constants
 

--- a/scripts/check-constants-sync.ts
+++ b/scripts/check-constants-sync.ts
@@ -59,6 +59,8 @@ const OWNED_PYTHON_PATTERNS: ReadonlyArray<{ name: string; regex: RegExp }> = [
   { name: 'DEFAULT_APPROVAL_GATE_CAP', regex: /^\s*DEFAULT_APPROVAL_GATE_CAP\s*(?::\s*int)?\s*=\s*-?\d+\b/m },
   { name: 'APPROVAL_GATE_CAP_MIN', regex: /^\s*APPROVAL_GATE_CAP_MIN\s*(?::\s*int)?\s*=\s*-?\d+\b/m },
   { name: 'APPROVAL_GATE_CAP_MAX', regex: /^\s*APPROVAL_GATE_CAP_MAX\s*(?::\s*int)?\s*=\s*-?\d+\b/m },
+  { name: 'FLOOR_TIMEOUT_S', regex: /^\s*FLOOR_TIMEOUT_S\s*(?::\s*int)?\s*=\s*-?\d+\b/m },
+  { name: 'DEFAULT_TASK_TIMEOUT_S', regex: /^\s*DEFAULT_TASK_TIMEOUT_S\s*(?::\s*int)?\s*=\s*-?\d+\b/m },
 ];
 
 interface Drift {
@@ -83,7 +85,10 @@ function findDriftInPython(filePath: string): Drift[] {
 
 function main(): number {
   // Sanity: confirm the JSON is parseable and shaped as expected.
-  let json: { approval_gate_cap?: { min: number; max: number; default: number } };
+  let json: {
+    approval_gate_cap?: { min: number; max: number; default: number };
+    approval_timeout_s?: { min: number; max: number; default: number };
+  };
   try {
     json = JSON.parse(fs.readFileSync(CONSTANTS_JSON, 'utf-8'));
   } catch (err) {
@@ -94,6 +99,12 @@ function main(): number {
   const agc = json.approval_gate_cap;
   if (!agc || typeof agc.min !== 'number' || typeof agc.max !== 'number' || typeof agc.default !== 'number') {
     console.error(`${CONSTANTS_JSON} is missing approval_gate_cap.{min,max,default}`);
+    return 1;
+  }
+
+  const ats = json.approval_timeout_s;
+  if (!ats || typeof ats.min !== 'number' || typeof ats.max !== 'number' || typeof ats.default !== 'number') {
+    console.error(`${CONSTANTS_JSON} is missing approval_timeout_s.{min,max,default}`);
     return 1;
   }
 


### PR DESCRIPTION
## Summary

- Migrates `APPROVAL_TIMEOUT_S_MIN/MAX/DEFAULT` (30/3600/300) from hardcoded literals to `contracts/constants.json` as the single source of truth across Python and TypeScript
- Extends the drift-detection script (`scripts/check-constants-sync.ts`) with `FLOOR_TIMEOUT_S` and `DEFAULT_TASK_TIMEOUT_S` patterns
- Updates `contracts/constants.md` schema documentation with the new key

Closes #116 (Batch 1: `approval_timeout_s`)

## Test plan

- [x] `scripts/check-constants-sync.ts` passes (5 Python names validated)
- [x] `tsc --noEmit` compiles cleanly in `cdk/`
- [x] CDK shared handler tests pass (30 suites, 723 tests)
- [x] CDK handler entry tests pass (5 suites, 131 tests)
- [x] Python `test_policy.py` passes (39 tests)
- [x] Python `test_hooks.py` passes (55 tests)
- [x] CI green