### PR TITLE
fix(cdk): enable Point-in-Time Recovery on UserConcurrencyTable

### DIFF
--- a/cdk/src/constructs/user-concurrency-table.ts
+++ b/cdk/src/constructs/user-concurrency-table.ts
@@ -36,6 +36,12 @@ export interface UserConcurrencyTableProps {
    * @default RemovalPolicy.DESTROY
    */
   readonly removalPolicy?: RemovalPolicy;
+
+  /**
+   * Whether to enable point-in-time recovery.
+   * @default true
+   */
+  readonly pointInTimeRecovery?: boolean;
 }
 
 /**
@@ -44,9 +50,6 @@ export interface UserConcurrencyTableProps {
  * Schema: user_id (PK). Each item holds an atomic counter (active_count)
  * representing the number of currently running tasks for the user.
  * The application layer uses conditional updates for increment/decrement.
- *
- * No point-in-time recovery: this is transient counter data that can be
- * reconstructed from the Tasks table by a reconciliation process.
  */
 export class UserConcurrencyTable extends Construct {
   /**
@@ -64,6 +67,9 @@ export class UserConcurrencyTable extends Construct {
         type: dynamodb.AttributeType.STRING,
       },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecoverySpecification: {
+        pointInTimeRecoveryEnabled: props.pointInTimeRecovery ?? true,
+      },
       removalPolicy: props.removalPolicy ?? RemovalPolicy.DESTROY,
     });
   }

--- a/cdk/test/constructs/user-concurrency-table.test.ts
+++ b/cdk/test/constructs/user-concurrency-table.test.ts
@@ -45,9 +45,11 @@ describe('UserConcurrencyTable', () => {
     });
   });
 
-  test('does not enable point-in-time recovery', () => {
+  test('enables point-in-time recovery by default', () => {
     template.hasResourceProperties('AWS::DynamoDB::Table', {
-      PointInTimeRecoverySpecification: Match.absent(),
+      PointInTimeRecoverySpecification: {
+        PointInTimeRecoveryEnabled: true,
+      },
     });
   });
 
@@ -94,6 +96,19 @@ describe('UserConcurrencyTable with custom props', () => {
     template.hasResource('AWS::DynamoDB::Table', {
       DeletionPolicy: 'Retain',
       UpdateReplacePolicy: 'Retain',
+    });
+  });
+
+  test('allows disabling point-in-time recovery', () => {
+    const app = new App();
+    const stack = new Stack(app, 'TestStack');
+    new UserConcurrencyTable(stack, 'UserConcurrencyTable', { pointInTimeRecovery: false });
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties('AWS::DynamoDB::Table', {
+      PointInTimeRecoverySpecification: {
+        PointInTimeRecoveryEnabled: false,
+      },
     });
   });
 });


### PR DESCRIPTION
## Summary

- Enables PITR on `UserConcurrencyTable`, the last DynamoDB table without it
- Adds `pointInTimeRecovery` opt-out prop (default `true`) for consistency with all other table constructs
- Uses `pointInTimeRecoverySpecification` (non-deprecated) matching the pattern in `TaskTable`, `RepoTable`, etc.

Closes #205

## Test plan

- [x] Unit tests pass (`npx jest --testPathPatterns="user-concurrency-table"` — 9/9 passing)
- [x] `mise //cdk:synth` produces additive diff (no table replacement)
- [x] Verify PITR prop defaults to `true` and can be overridden to `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)