### PR TITLE
fix(slack): bump command processor memory to 512 MB

### DIFF
--- a/cdk/src/constructs/slack-integration.ts
+++ b/cdk/src/constructs/slack-integration.ts
@@ -238,12 +238,17 @@ export class SlackIntegration extends Construct {
     }));
 
     // --- Slash Command Processor (async worker) ---
+    // Memory bumped from default 128 MB → 512 MB after module-init OOM
+    // surfaced in dev. Bundle grew past the 128 MB cap once createTaskCore's
+    // transitive dependency graph (Cedar, attachment-screening) imported
+    // here through the shared task-creation path.
     const commandProcessorFn = new lambda.NodejsFunction(this, 'CommandProcessorFn', {
       entry: path.join(handlersDir, 'slack-command-processor.ts'),
       handler: 'handler',
       runtime: Runtime.NODEJS_24_X,
       architecture: Architecture.ARM_64,
       timeout: Duration.seconds(30),
+      memorySize: 512,
       environment: {
         ...createTaskEnv,
         SLACK_USER_MAPPING_TABLE_NAME: this.userMappingTable.tableName,


### PR DESCRIPTION
## Summary

Closes #231.

The Slack `CommandProcessorFn` runs at the CDK default of 128 MB and OOMs during module init after `createTaskCore`'s transitive dependency graph (Cedar, attachment-screening, etc.) crossed the ceiling. Bump to 512 MB to match the Linear webhook processor (already at 512 from #d843540).

Symptom: `@bgagent` mentions in Slack get the 👀 reaction (receiver acks the event) but never the follow-up acknowledgement — the processor crashes before doing anything. CloudWatch shows:

```
INIT_REPORT ... Phase: init  Status: error  Error Type: Runtime.OutOfMemory
REPORT ... Memory Size: 128 MB  Max Memory Used: 127 MB
```

#232 tracks the deeper followup (lazy-load attachment / Cedar deps in `createTaskCore` so processors don't need 512 MB).

## Test plan

- [x] Verified locally on dev stack: bumped memory, redeployed, `aws lambda get-function-configuration` returns `MemorySize: 512`, `@Shoof` mentions complete end-to-end (👀 → task created → acknowledgement comment posted)
- [ ] CI: build + tests pass