### PR TITLE
docs: changed 6 steps to 7 steps in the related docs section

### DIFF
--- a/docs/guides/DEPLOYMENT_GUIDE.md
+++ b/docs/guides/DEPLOYMENT_GUIDE.md
@@ -163,7 +163,7 @@ Triggers via `workflow_run` when `build.yml` completes successfully. The pipelin
 
 ## Related docs
 
-- [Quick start](./QUICK_START.md) -- Zero-to-first-PR in 6 steps.
+- [Quick start](./QUICK_START.md) -- Zero-to-first-PR in 7 steps.
 - [Developer guide](./DEVELOPER_GUIDE.md) -- Local development, testing, repository onboarding.
 - [User guide](./USER_GUIDE.md) -- API reference, CLI usage, task management.
 - [DEPLOYMENT_ROLES.md](../design/DEPLOYMENT_ROLES.md) -- Least-privilege IAM policies for CloudFormation execution.


### PR DESCRIPTION
<!-- Summarize the pull request -->
In the related docs section of DEPLOYMENT_GUIDE.md, it mistakenly had 6 steps when in reality it shows 7 steps. 

#### Area

<!-- Check all that apply -->

- [ ] `cdk` — infrastructure, handlers, constructs
- [ ] `agent` — Python runtime / Docker image
- [ ] `cli` — `bgagent` client
- [ ] `docs` — guides or design sources (`docs/guides/`, `docs/design/`)
- [ ] `tooling` — root `mise.toml`, scripts, CI workflows

Tip: [AGENTS.md](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/blob/main/AGENTS.md) lists where to edit and which tests to extend.

#### Related

<!-- Issue #, Vulnerability, References if available:* -->

#### Changes

<!-- Description of changes:* -->

#### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/blob/main/LICENSE).
