### PR TITLE
fix(ci): upgrade download-artifact v4.3.0 → v8.0.1 (Node 24)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       run_id: ${{ github.event.workflow_run.id }}
     steps:
       - name: Download deploy intent
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: deploy-intent
           run-id: ${{ github.event.workflow_run.id }}
@@ -145,7 +145,7 @@ jobs:
           persist-credentials: false
 
       - name: Download CDK artifact (${{ matrix.compute_type }})
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cdk-${{ matrix.compute_type }}-out
           path: cdk/
@@ -220,7 +220,7 @@ jobs:
           persist-credentials: false
 
       - name: Download CDK artifact (${{ matrix.compute_type }})
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: cdk-${{ matrix.compute_type }}-out
           path: cdk/


### PR DESCRIPTION
## Summary

- Upgrades all 3 `actions/download-artifact` pins in `deploy.yml` from v4.3.0 (Node 20) to v8.0.1 (Node 24)
- Resolves GitHub deprecation warning: Node.js 20 actions forced to Node 24 on June 16, 2026

## Context

CI annotation on [run 26907540645](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/actions/runs/26907540645):
> Node.js 20 actions are deprecated. [...] Actions will be forced to run with Node.js 24 by default starting June 16th, 2026.

v8 breaking changes (assessed as safe):
1. Hash mismatch defaults to `error` (more secure; standard uploads pass)
2. Non-zipped files not auto-extracted (our uploads are zipped)
3. ESM module (transparent to callers)

All inputs used (`name`, `run-id`, `github-token`, `path`) remain compatible.

Closes #261

## Test plan

- [ ] CI build workflow passes (no deprecation annotation for download-artifact)
- [ ] `deploy.yml` `resolve-targets` job can still download `deploy-intent` artifact cross-workflow
- [ ] `diff` and `deploy` jobs can still download `cdk-*-out` artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)