### PR TITLE
fix(security): constrain pyjwt >=2.13.0 (PYSEC-2026-175/177/178/179)

### DIFF
--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -36,6 +36,11 @@ dependencies = [
     "cedarpy==4.8.0", #https://github.com/k9securityio/cedar-py — EXACT pin (no ^/~), parity with @cedar-policy/cedar-wasm@4.10.0
 ]
 
+[tool.uv]
+constraint-dependencies = [
+    "pyjwt>=2.13.0",  # PYSEC-2026-175/177/178/179 — transitive via mcp; remove when mcp bumps floor (#267)
+]
+
 [tool.bandit]
 exclude_dirs = ["tests", ".venv"]
 skips = [

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -6,6 +6,9 @@ resolution-markers = [
     "python_full_version < '3.14'",
 ]
 
+[manifest]
+constraints = [{ name = "pyjwt", specifier = ">=2.13.0" }]
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -1796,11 +1799,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- Adds `[tool.uv] constraint-dependencies` for `pyjwt>=2.13.0` in `agent/pyproject.toml`
- Regenerates `agent/uv.lock` (pyjwt 2.12.1 → 2.13.0)
- Resolves 4 CVEs (PYSEC-2026-175/177/178/179, including one High CVSS 7.4)
- Unblocks the `osv-scanner` pre-push hook for all contributors

## Why constraint-dependencies

`pyjwt` is a transitive dependency (via `mcp==1.27.1`). `mcp` hasn't bumped its floor yet, so Dependabot can't propose a fix. `constraint-dependencies` tells uv "never resolve below 2.13.0" while respecting `mcp`'s compatibility range — safer than `override-dependencies`.

Backlog issue #267 tracks removing this constraint when `mcp` bumps its own pyjwt floor.

Closes #266

## Test plan

- [x] `osv-scanner scan --lockfile agent/uv.lock` — no issues found
- [x] `mise //agent:quality` — 819 tests pass, 72.57% coverage
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)