### PR TITLE
docs(deployment): add AWS CLI recovery path for DNS Query Log replacement

### DIFF
--- a/docs/guides/DEPLOYMENT_GUIDE.md
+++ b/docs/guides/DEPLOYMENT_GUIDE.md
@@ -177,13 +177,24 @@ Triggers via `workflow_run` when `build.yml` completes successfully. The pipelin
 
 **Resolution — choose one:**
 
-#### Option A: Manual disassociation via AWS Console (recommended)
+#### Option A: AWS CLI disassociation (recommended)
 
-1. Open the [Route 53 Resolver console](https://console.aws.amazon.com/route53resolver/home#/query-logging)
-2. Select the query logging configuration named `agent-dns-query-log`
-3. Under **Associated VPCs**, disassociate the VPC
-4. Delete the query logging configuration
-5. Run `mise //cdk:deploy` (or `cdk deploy`) — CloudFormation will recreate both resources without tags
+Fastest, scriptable, no console access required. Replace `<vpc-id>` with the agent VPC ID and `<region>` with your stack's region.
+
+1. List the association for your VPC to get the `ResolverQueryLogConfigId`:
+   ```bash
+   aws route53resolver list-resolver-query-log-config-associations \
+     --region <region> \
+     --query "ResolverQueryLogConfigAssociations[?ResourceId=='<vpc-id>']"
+   ```
+2. Disassociate using the `Id` from step 1:
+   ```bash
+   aws route53resolver disassociate-resolver-query-log-config \
+     --resolver-query-log-config-id <rqlc-id> \
+     --resource-id <vpc-id> \
+     --region <region>
+   ```
+3. Run `mise //cdk:deploy` — CloudFormation recreates both the config and association without the orphan tags. The pre-existing `ResolverQueryLoggingConfig` is replaced as part of the same update, so an explicit `delete-resolver-query-log-config` is not required.
 
 #### Option B: Two-phase deploy (comment-out / re-add)
 
@@ -199,7 +210,17 @@ Triggers via `workflow_run` when `build.yml` completes successfully. The pipelin
 3. Uncomment the `DnsFirewall` block
 4. Deploy again: `mise //cdk:deploy` — resources are recreated cleanly without tags
 
-Option B is more disruptive (two deploys, brief DNS logging gap) but requires no console access.
+Option B is more disruptive (two deploys, brief DNS logging gap) but requires no AWS API access beyond `cdk deploy`.
+
+#### Option C: Manual disassociation via AWS Console
+
+For users without AWS CLI access.
+
+1. Open the [Route 53 Resolver console](https://console.aws.amazon.com/route53resolver/home#/query-logging)
+2. Select the query logging configuration named `agent-dns-query-log`
+3. Under **Associated VPCs**, disassociate the VPC
+4. Delete the query logging configuration
+5. Run `mise //cdk:deploy` (or `cdk deploy`) — CloudFormation will recreate both resources without tags
 
 ## Related docs
 

--- a/docs/src/content/docs/getting-started/Deployment-guide.md
+++ b/docs/src/content/docs/getting-started/Deployment-guide.md
@@ -181,13 +181,24 @@ Triggers via `workflow_run` when `build.yml` completes successfully. The pipelin
 
 **Resolution — choose one:**
 
-#### Option A: Manual disassociation via AWS Console (recommended)
+#### Option A: AWS CLI disassociation (recommended)
 
-1. Open the [Route 53 Resolver console](https://console.aws.amazon.com/route53resolver/home#/query-logging)
-2. Select the query logging configuration named `agent-dns-query-log`
-3. Under **Associated VPCs**, disassociate the VPC
-4. Delete the query logging configuration
-5. Run `mise //cdk:deploy` (or `cdk deploy`) — CloudFormation will recreate both resources without tags
+Fastest, scriptable, no console access required. Replace `<vpc-id>` with the agent VPC ID and `<region>` with your stack's region.
+
+1. List the association for your VPC to get the `ResolverQueryLogConfigId`:
+   ```bash
+   aws route53resolver list-resolver-query-log-config-associations \
+     --region <region> \
+     --query "ResolverQueryLogConfigAssociations[?ResourceId=='<vpc-id>']"
+   ```
+2. Disassociate using the `Id` from step 1:
+   ```bash
+   aws route53resolver disassociate-resolver-query-log-config \
+     --resolver-query-log-config-id <rqlc-id> \
+     --resource-id <vpc-id> \
+     --region <region>
+   ```
+3. Run `mise //cdk:deploy` — CloudFormation recreates both the config and association without the orphan tags. The pre-existing `ResolverQueryLoggingConfig` is replaced as part of the same update, so an explicit `delete-resolver-query-log-config` is not required.
 
 #### Option B: Two-phase deploy (comment-out / re-add)
 
@@ -203,7 +214,17 @@ Triggers via `workflow_run` when `build.yml` completes successfully. The pipelin
 3. Uncomment the `DnsFirewall` block
 4. Deploy again: `mise //cdk:deploy` — resources are recreated cleanly without tags
 
-Option B is more disruptive (two deploys, brief DNS logging gap) but requires no console access.
+Option B is more disruptive (two deploys, brief DNS logging gap) but requires no AWS API access beyond `cdk deploy`.
+
+#### Option C: Manual disassociation via AWS Console
+
+For users without AWS CLI access.
+
+1. Open the [Route 53 Resolver console](https://console.aws.amazon.com/route53resolver/home#/query-logging)
+2. Select the query logging configuration named `agent-dns-query-log`
+3. Under **Associated VPCs**, disassociate the VPC
+4. Delete the query logging configuration
+5. Run `mise //cdk:deploy` (or `cdk deploy`) — CloudFormation will recreate both resources without tags
 
 ## Related docs
 


### PR DESCRIPTION
## Summary

- Adds an AWS CLI recovery path to the **DNS Query Log Config replacement cascade** runbook in `docs/guides/DEPLOYMENT_GUIDE.md` (and the synced Starlight mirror).
- Reorders the three recovery options: **A** = AWS CLI (new, fastest, scriptable), **B** = two-phase deploy (unchanged), **C** = console disassociation (was A).
- Notes that the orphaned `ResolverQueryLoggingConfig` is replaced as part of the same CFN update — no explicit `delete-resolver-query-log-config` is required.

The CLI flow is the one I used to unstick a real `backgroundagent-dev` deploy; the previous Option A (console clicks) is preserved as Option C for users without CLI access.

## Test plan

- [ ] `mise //docs:sync` produces no diff (Starlight mirror is in sync — already committed)
- [ ] CI's "Fail build on mutation" docs check passes
- [ ] Markdown renders correctly in the rendered Starlight site
- [ ] Reviewer with shell access can copy-paste the Option A commands into a terminal and reproduce the recovery flow

Closes #272
Follows up #270 / #269.