### PR TITLE
fix(security): suppress prototype-pollution-loop false positive in check-types-sync.ts

### DIFF
--- a/scripts/check-types-sync.ts
+++ b/scripts/check-types-sync.ts
@@ -283,6 +283,7 @@ function resolveConstantsReference(
   let value: unknown = SHARED_CONSTANTS;
   for (const seg of segments) {
     if (value == null || typeof value !== 'object') return undefined;
+    // nosemgrep: javascript.lang.security.audit.prototype-pollution.prototype-pollution-loop.prototype-pollution-loop -- read-only walk down build-time-trusted contracts/constants.json; `seg` keys come from this script's own TS AST, not external input, and no object property is ever assigned (value is reassigned, never written).
     value = (value as Record<string, unknown>)[seg];
   }
   if (value == null || typeof value === 'object') return undefined;


### PR DESCRIPTION
## What

Suppresses a Semgrep **false positive** that has kept the scheduled `mise run security` suite RED on `main`.

`semgrep --config auto` flags `scripts/check-types-sync.ts:286` with `prototype-pollution-loop`:

```ts
value = (value as Record<string, unknown>)[seg];
```

This is a false positive. `resolveConstantsReference` walks a property chain **down** `SHARED_CONSTANTS` (the build-time-trusted `contracts/constants.json`): it **reads** `value[seg]` and reassigns the local `value`, and never assigns to any object property — so there is no prototype-pollution sink. The `seg` keys come from this script's own TypeScript AST, not external input.

## Why it's RED now

The flagged line was introduced on 2026-06-02 by `80bf1f8` (the #234 fix), which also cleared the *previous* red cause (trivy HIGH on `gh` 2.92.0 / CVE-2026-48501). So `main` went red-for-CVE → red-for-this-FP, and `security.yml` (schedule-only) has failed its last two runs (`06-01`, `06-08`).

## Fix

An inline, justified `// nosemgrep`, matching the repo's existing convention (`cli/src/commands/submit.ts:232`, `agent/src/config.py:165`). Keeping it inline — rather than a blanket `.semgrepignore` or rule disable — leaves every other prototype-pollution site gated.

```ts
// nosemgrep: javascript.lang.security.audit.prototype-pollution.prototype-pollution-loop.prototype-pollution-loop -- read-only walk down build-time-trusted contracts/constants.json; `seg` keys come from this script's own TS AST, not external input, and no object property is ever assigned (value is reassigned, never written).
value = (value as Record<string, unknown>)[seg];
```

## Verification

`semgrep scan --config auto scripts/check-types-sync.ts` → **0 findings (0 blocking)** (was 1 blocking).

## Notes

First **Semgrep** worked instance for the #277 / candidate ADR-014 finding-triage process (`dismissed-with-reason` / false-positive), alongside #276's CodeQL instance.

Closes #283
Refs #297

_— drafted by Bonk; opened via Laith's account._
