### PR TITLE
fix(ci): add uv to root tools so semgrep installs via uvx (#320)

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -18,6 +18,11 @@ experimental = true
 node = "22"
 prek = "latest"
 gitleaks = "latest"
+# uv must be declared so it is on PATH before semgrep installs: mise's
+# `pipx.uvx` default routes pipx tools through `uv tool install` when uv is
+# present, avoiding the classic-pipx "Failed to upgrade shared libraries" path
+# that breaks under the mise 2026.6.x default `minimum_release_age` (see #320).
+uv = "latest"
 semgrep = "latest"
 osv-scanner = "latest"
 "grype" = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -21,7 +21,8 @@ gitleaks = "latest"
 # uv must be declared so it is on PATH before semgrep installs: mise's
 # `pipx.uvx` default routes pipx tools through `uv tool install` when uv is
 # present, avoiding the classic-pipx "Failed to upgrade shared libraries" path
-# that breaks under the mise 2026.6.x default `minimum_release_age` (see #320).
+# that breaks under the mise 2026.6.x default `minimum_release_age`
+# (jdx/mise#10279; see #320).
 uv = "latest"
 semgrep = "latest"
 osv-scanner = "latest"


### PR DESCRIPTION
## Summary

Adds `uv = "latest"` to the **root** `mise.toml [tools]` so `semgrep` installs via the uvx backend instead of classic pipx.

Fixes the persistently-red `upgrade-main` workflow (3/3 runs, see #320) and pre-empts the same break in `security.yml`.

## Why

mise **2026.6.2** ([jdx/mise#10279](https://github.com/jdx/mise/pull/10279)) turned on a built-in default `minimum_release_age = "24h"` for timestamp-capable backends including pipx. With `semgrep = "latest"`, that activates a date-cutoff install path that first upgrades the tool's shared pip venv — the step that fails on the GitHub runner:

```
mise semgrep@1.165.0  [1/3] pipx install semgrep==1.165.0
Failed to upgrade shared libraries
mise ERROR pipx failed
```

mise's `pipx.uvx` setting defaults to `true` and routes pipx tools through `uv tool install` **when uv is on PATH** — but `uv` was only declared in `agent/mise.toml`, not the root `mise.toml` that `jdx/mise-action` provisions at the repo root. So root-level semgrep fell back to classic pipx → the failing path.

`build.yml` dodges this today by skipping semgrep via `MISE_DISABLE_TOOLS`; `upgrade-main` (new in #309) and `security.yml` don't, so they hit the break on a cold mise-action cache.

This is a mise backend regression, not a semgrep version issue — pinning semgrep would not help. Declaring `uv` is the root-cause fix and keeps the 2026.6.2 supply-chain release-age protection intact.

## Verification

Reproduced under the exact CI mise binary (`2026.6.3`), isolated HOME, with `uv` + `semgrep` both in `[tools]`:

```
mise uv@0.11.20        ✓ installed
mise semgrep@1.165.0   [1/3] uv tool install semgrep==1.165.0
   Built semgrep==1.165.0
Installed 2 executables: pysemgrep, semgrep
mise semgrep@1.165.0   ✓ installed   (exit 0)
```

mise resolves `uv` before `semgrep` automatically when both are declared, so no explicit ordering step is needed.

## Test plan

- [ ] `upgrade-main` scheduled/dispatched run goes green (mise install → `mise run upgrade` → patch/PR).
- [ ] `security.yml` provisions semgrep without "Failed to upgrade shared libraries" on a cold cache.

Closes #320

---

*Drafted by Bonk during the ABCA nightly review; opened via Laith's account.*
