### PR TITLE
fix(project): fix multiple issues identified

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -3,16 +3,19 @@ name: auto-approve
 # upgrade-main dependency PRs). pull_request_target is intentional and safe
 # here: the job never checks out or executes PR code — it only calls the
 # review API. Branch protection still requires the build workflow to pass.
+#
+# Trigger is `labeled` ONLY: each approval requires an explicit label event
+# from someone with triage+ permission. Approving on `synchronize` would
+# re-approve arbitrary future commits pushed to an already-labeled PR with no
+# human re-review — combined with Mergify's auto-merge that is an
+# unreviewed-merge path. The Mergify `dismiss stale approvals` rule is the
+# other half of this invariant: a push invalidates the bot's prior approval,
+# and re-approval requires removing and re-adding the label (deliberate
+# friction: new content needs a fresh, explicit trigger).
 on:
   pull_request_target:
     types:
       - labeled
-      - unlabeled
-      - opened
-      - synchronize
-      - reopened
-      - ready_for_review
-      - review_requested
 permissions:
   actions: none
   attestations: none
@@ -34,7 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: contains(github.event.pull_request.labels.*.name, 'auto-approve')
+    # Only act on the auto-approve label itself, and never on fork PRs —
+    # a fork head can be force-pushed by the fork owner after labeling.
+    if: |
+      github.event.label.name == 'auto-approve' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         with:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,6 +11,18 @@ queue_rules:
 
       {{ body }}
 pull_request_rules:
+  # Approvals must cover the commits actually being merged. Without this,
+  # the auto-approve bot's review (or any human review) would keep
+  # satisfying `#approved-reviews-by>=1` after arbitrary new commits are
+  # pushed, letting unreviewed content auto-merge. Dismissing on every
+  # push forces a fresh approval (for label-gated PRs: remove and re-add
+  # the `auto-approve` label) before the queue rule can fire again.
+  - name: Dismiss stale approvals when new commits are pushed
+    conditions:
+      - base=main
+    actions:
+      dismiss_reviews:
+        approved: true
   - name: Automatic merge on approval and successful build
     actions:
       delete_head_branch: {}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ The `@backgroundagent/cli` package provides the `bgagent` executable for submitt
 - `src/api-client.ts` — HTTP client wrapping `fetch` with auth header injection
 - `src/auth.ts` — Cognito login, token caching (`~/.bgagent/credentials.json`), auto-refresh
 - `src/config.ts` — Read/write `~/.bgagent/config.json`
-- `src/types.ts` — API request/response types (mirrored from `cdk/src/handlers/shared/types.ts`), including `TaskType` (`new_task` | `pr_iteration` | `pr_review`)
+- `src/types.ts` — API request/response types (mirrored from `cdk/src/handlers/shared/types.ts`), including `workflow_ref` / `ResolvedWorkflow` (workflow ids like `coding/new-task-v1`, `coding/pr-iteration-v1`, `coding/pr-review-v1`; replaced the former `TaskType` enum, #248)
 - `src/format.ts` — Output formatting (table, detail view, JSON)
 - `src/debug.ts` — Verbose/debug logging (`--verbose` flag)
 - `src/errors.ts` — `CliError` and `ApiError` classes

--- a/agent/src/hooks.py
+++ b/agent/src/hooks.py
@@ -24,6 +24,7 @@ import os
 import re
 import time
 from collections.abc import Callable
+from datetime import UTC
 from typing import TYPE_CHECKING, Any
 
 import nudge_reader
@@ -805,7 +806,12 @@ def _remaining_maxlifetime_s() -> int | None:
         else:
             from datetime import datetime
 
-            started_epoch = int(datetime.strptime(started_at, "%Y-%m-%dT%H:%M:%SZ").timestamp())
+            # The trailing Z means UTC; strptime returns a naive datetime whose
+            # .timestamp() would otherwise be interpreted in the container's
+            # local TZ, skewing remaining-lifetime math by the UTC offset.
+            started_epoch = int(
+                datetime.strptime(started_at, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC).timestamp()
+            )
     except (ValueError, AttributeError):
         return None
     elapsed = int(time.time()) - started_epoch

--- a/agent/src/output_scanner.py
+++ b/agent/src/output_scanner.py
@@ -42,9 +42,15 @@ _PATTERNS: list[tuple[str, re.Pattern[str]]] = [
             re.IGNORECASE,
         ),
     ),
-    # GitHub tokens (PAT, OAuth, App, user-to-server, fine-grained)
-    ("GITHUB_TOKEN", re.compile(r"(?:ghp|gho|ghs|ghu)_[a-zA-Z0-9]{36}")),
+    # GitHub tokens (PAT, OAuth, App, user-to-server, refresh, fine-grained).
+    # Length is variable across token generations — match 36+ chars rather
+    # than exactly 36 so newer/longer formats are still caught.
+    ("GITHUB_TOKEN", re.compile(r"(?:ghp|gho|ghs|ghu|ghr)_[a-zA-Z0-9]{36,}")),
     ("GITHUB_PAT", re.compile(r"github_pat_[a-zA-Z0-9_]{22,}")),
+    # Credentials embedded in git remote URLs (https://x-access-token:TOKEN@github.com/...).
+    # The agent authenticates via env-based credential helper, but tool output
+    # may still echo such URLs from other sources.
+    ("GITHUB_URL_TOKEN", re.compile(r"x-access-token:[^\s@\"']+@")),
     # Private keys (PEM blocks)
     (
         "PRIVATE_KEY",

--- a/agent/src/repo.py
+++ b/agent/src/repo.py
@@ -44,18 +44,28 @@ def setup_repo(config: TaskConfig) -> RepoSetup:
         label="clone",
     )
 
-    # Configure remote URL with embedded token so git push works without
-    # credential helpers or extra auth setup inside the agent.
-    token = config.github_token
+    # Pin the remote to the plain https URL (no embedded credentials) and
+    # authenticate git push via gh's credential helper. Embedding the token
+    # in the remote URL would persist it in .git/config inside the workspace
+    # the agent (and any code it runs) fully controls — readable by a
+    # prompt-injected step, `git remote -v`, or anything that copies the
+    # tree. The helper resolves credentials at call time from the
+    # GH_TOKEN/GITHUB_TOKEN env vars the caller exports before setup_repo(),
+    # so the token never touches disk.
     run_cmd(
         [
             "git",
             "remote",
             "set-url",
             "origin",
-            f"https://x-access-token:{token}@github.com/{config.repo_url}.git",
+            f"https://github.com/{config.repo_url}.git",
         ],
         label="set-remote-url",
+        cwd=repo_dir,
+    )
+    run_cmd(
+        ["git", "config", "--local", "credential.helper", "!gh auth git-credential"],
+        label="configure-git-credential-helper",
         cwd=repo_dir,
     )
 

--- a/agent/tests/test_hooks.py
+++ b/agent/tests/test_hooks.py
@@ -321,6 +321,7 @@ class TestBuildHookMatchers:
 import hashlib
 import json as _json
 from collections import deque
+from datetime import UTC
 from typing import Any
 
 import hooks
@@ -1412,3 +1413,44 @@ class TestDenialBetweenTurnsHook:
         # DDB and returns []. Denial should be injected.
         assert result.get("decision") == "block"
         assert "<user_denial" in result.get("reason", "")
+
+
+class TestRemainingMaxlifetime:
+    """_remaining_maxlifetime_s parses TASK_STARTED_AT correctly."""
+
+    def test_iso_timestamp_parsed_as_utc_regardless_of_local_tz(self, monkeypatch):
+        # The trailing Z means UTC. Before the fix, strptime produced a naive
+        # datetime whose .timestamp() used the container's local TZ, skewing
+        # the remaining-lifetime math by the UTC offset (wrong approval
+        # timeouts / spurious insufficient-lifetime denies on non-UTC hosts).
+        import time as time_module
+        from datetime import datetime
+
+        started = datetime(2026, 6, 11, 12, 0, 0, tzinfo=UTC)
+        monkeypatch.setenv("TASK_STARTED_AT", "2026-06-11T12:00:00Z")
+        monkeypatch.setenv("AGENTCORE_MAX_LIFETIME_S", "28800")
+        # Freeze "now" at exactly 1000s after the UTC start time.
+        monkeypatch.setattr(hooks.time, "time", lambda: started.timestamp() + 1000, raising=True)
+        # Simulate a non-UTC container: if the implementation regresses to
+        # local-time interpretation, the result shifts by the TZ offset.
+        monkeypatch.setenv("TZ", "America/New_York")
+        time_module.tzset()
+        try:
+            assert hooks._remaining_maxlifetime_s() == 28800 - 1000
+        finally:
+            monkeypatch.delenv("TZ")
+            time_module.tzset()
+
+    def test_epoch_seconds_passthrough(self, monkeypatch):
+        monkeypatch.setenv("TASK_STARTED_AT", "1000000")
+        monkeypatch.setenv("AGENTCORE_MAX_LIFETIME_S", "500")
+        monkeypatch.setattr(hooks.time, "time", lambda: 1000100, raising=True)
+        assert hooks._remaining_maxlifetime_s() == 400
+
+    def test_missing_started_at_returns_none(self, monkeypatch):
+        monkeypatch.delenv("TASK_STARTED_AT", raising=False)
+        assert hooks._remaining_maxlifetime_s() is None
+
+    def test_unparseable_started_at_returns_none(self, monkeypatch):
+        monkeypatch.setenv("TASK_STARTED_AT", "not-a-timestamp")
+        assert hooks._remaining_maxlifetime_s() is None

--- a/agent/tests/test_output_scanner.py
+++ b/agent/tests/test_output_scanner.py
@@ -63,6 +63,23 @@ class TestScanToolOutput:
         assert "GITHUB_PAT detected" in result.findings
         assert "[REDACTED-GITHUB_PAT]" in result.redacted_content
 
+    def test_detects_token_longer_than_36_chars(self):
+        # Token lengths vary across generations; the pattern must not be
+        # anchored to exactly 36 chars.
+        content = "token: ghs_" + "A" * 48
+        result = scan_tool_output(content)
+        assert result.has_sensitive_content is True
+        assert "GITHUB_TOKEN detected" in result.findings
+        assert "ghs_" not in result.redacted_content
+
+    def test_detects_token_in_remote_url(self):
+        # `git remote -v` style output with x-access-token credentials.
+        content = "origin  https://x-access-token:ghs_secret123@github.com/owner/repo.git (push)"
+        result = scan_tool_output(content)
+        assert result.has_sensitive_content is True
+        assert "GITHUB_URL_TOKEN detected" in result.findings
+        assert "ghs_secret123" not in result.redacted_content
+
     # ---- Private keys ----
 
     def test_detects_rsa_private_key(self):

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -2,9 +2,6 @@
   "app": "npx ts-node -P tsconfig.json --prefer-ts-exts src/main.ts",
   "output": "cdk.out",
   "build": "node -e \"process.exit(0)\"",
-  "context": {
-    "blueprintRepo": "krokoko/agent-plugins"
-  },
   "watch": {
     "include": ["src/**/*.ts", "test/**/*.ts"],
     "exclude": [

--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -2,6 +2,9 @@
   "app": "npx ts-node -P tsconfig.json --prefer-ts-exts src/main.ts",
   "output": "cdk.out",
   "build": "node -e \"process.exit(0)\"",
+  "context": {
+    "blueprintRepo": "krokoko/agent-plugins"
+  },
   "watch": {
     "include": ["src/**/*.ts", "test/**/*.ts"],
     "exclude": [

--- a/cdk/src/handlers/shared/agentcore-browser.ts
+++ b/cdk/src/handlers/shared/agentcore-browser.ts
@@ -156,12 +156,38 @@ async function runCdpScreenshot(wssUrl: string, url: string, timeoutMs: number):
   }
   const eventWaiters: EventWaiter[] = [];
 
+  // Track the latest Document response status PER FRAME so we can fail fast
+  // on 4xx/5xx (404 / 503 / auth wall pages) instead of capturing what looks
+  // like the app but isn't. The main frame's id is only known once
+  // Page.navigate resolves, but `Network.responseReceived` for the main
+  // document frequently arrives BEFORE that response — so record every
+  // Document status keyed by frameId and resolve which one is the main
+  // document afterwards. (Recording a single "latest" status instead would
+  // race: an early sub-frame response could be misattributed as the main
+  // document, or the real main-document status missed entirely.)
+  // Redirect chains re-fire for the same frameId; last write wins, which is
+  // the final response. (Auth walls that return 200 are out of scope — #287.)
+  const documentStatusByFrame = new Map<string, number>();
+
   ws.on('message', (raw: RawData) => {
     const data = raw.toString();
     let msg: CdpMessage;
     try {
       msg = JSON.parse(data) as CdpMessage;
     } catch {
+      return;
+    }
+    if (msg.method === 'Network.responseReceived') {
+      const params = msg.params as
+        | { type?: string; frameId?: string; response?: { status?: number } }
+        | undefined;
+      // CDP's `Network.responseReceived` fires for every resource (HTML,
+      // JS, CSS, images, XHR, …). Only type==='Document' responses are
+      // candidate main-document responses.
+      if (params?.type === 'Document' && typeof params.frameId === 'string') {
+        const status = params.response?.status;
+        if (typeof status === 'number') documentStatusByFrame.set(params.frameId, status);
+      }
       return;
     }
     if (typeof msg.id === 'number') {
@@ -262,14 +288,6 @@ async function runCdpScreenshot(wssUrl: string, url: string, timeoutMs: number):
     });
   }
 
-  // Track the main-document HTTP response so we can fail fast on 4xx/5xx
-  // (404 / 503 / auth wall pages) instead of capturing what looks like the
-  // app but isn't. Captured in a Network.responseReceived listener below;
-  // checked after Page.loadEventFired but before Page.captureScreenshot.
-  // (Auth walls that return 200 are out of scope — see issue #287.)
-  let mainDocumentStatus: number | null = null;
-  let mainDocumentFrameId: string | null = null;
-
   try {
     // 1. List existing targets, find the default about:blank page.
     const targetsResp = await cdpSend('Target.getTargets');
@@ -293,33 +311,10 @@ async function runCdpScreenshot(wssUrl: string, url: string, timeoutMs: number):
     //    we wait on below AND the main-document response status. Network
     //    has to be enabled BEFORE Page.navigate, or the response event
     //    fires before our listener is wired and we miss the status.
+    //    (Document statuses are recorded per-frame by the single message
+    //    listener above; we resolve the main frame's status after load.)
     await cdpSend('Page.enable', {}, pageSessionId);
     await cdpSend('Network.enable', {}, pageSessionId);
-
-    // Tap the raw message stream for Network.responseReceived events —
-    // we want a multi-fire listener (Document responses can appear for
-    // redirect chains), not the one-shot waiter pattern that
-    // eventWaiters / waitForEvent use. Records the latest matching
-    // status; the post-load check below acts on whatever was captured.
-    ws.on('message', (raw: RawData) => {
-      let msg: CdpMessage;
-      try {
-        msg = JSON.parse(raw.toString()) as CdpMessage;
-      } catch {
-        return;
-      }
-      if (msg.method !== 'Network.responseReceived') return;
-      const params = msg.params as
-        | { type?: string; frameId?: string; response?: { status?: number } }
-        | undefined;
-      // CDP's `Network.responseReceived` fires for every resource (HTML,
-      // JS, CSS, images, XHR, …). Only the type==='Document' event for
-      // the navigated frame is the main-document response we care about.
-      if (!params || params.type !== 'Document') return;
-      if (mainDocumentFrameId && params.frameId !== mainDocumentFrameId) return;
-      const status = params.response?.status;
-      if (typeof status === 'number') mainDocumentStatus = status;
-    });
 
     // 4. Navigate. The response includes a `frameId`; we wait on the
     //    `Page.loadEventFired` event below (more reliable than
@@ -330,7 +325,7 @@ async function runCdpScreenshot(wssUrl: string, url: string, timeoutMs: number):
     if (navError) {
       throw new Error(`Page.navigate failed: ${navError}`);
     }
-    mainDocumentFrameId = (navResp.result?.frameId as string | undefined) ?? null;
+    const mainDocumentFrameId = (navResp.result?.frameId as string | undefined) ?? null;
 
     // 5. Wait for the page load event. SPA-style apps may continue
     //    fetching after this fires, so add a 2s settle wait. For
@@ -344,10 +339,21 @@ async function runCdpScreenshot(wssUrl: string, url: string, timeoutMs: number):
     //    perspective; the user sees a confidently-wrong screenshot of an
     //    error page posted as the deploy preview. Throw → processor's
     //    catch logs and skips the PR/Linear comment cleanly.
-    //    If we never captured a status (Network.responseReceived was
-    //    queued but predicate didn't match — e.g. a redirect chain that
-    //    doesn't expose the final frame), fall through and capture
+    //    The main frame's id comes from the Page.navigate response; its
+    //    Document responses were recorded per-frame by the message
+    //    listener even if they arrived before navigate resolved. If
+    //    Page.navigate returned no frameId, only an unambiguous single
+    //    recorded status is trusted — with multiple frames we cannot
+    //    tell which is the main document.
+    //    If we never captured a status (e.g. a service variant that
+    //    doesn't emit Network events), fall through and capture
     //    optimistically; that's the pre-#287 behaviour.
+    let mainDocumentStatus: number | null = null;
+    if (mainDocumentFrameId !== null) {
+      mainDocumentStatus = documentStatusByFrame.get(mainDocumentFrameId) ?? null;
+    } else if (documentStatusByFrame.size === 1) {
+      mainDocumentStatus = documentStatusByFrame.values().next().value ?? null;
+    }
     if (mainDocumentStatus !== null && (mainDocumentStatus < 200 || mainDocumentStatus >= 300)) {
       throw new Error(`Preview URL returned HTTP ${mainDocumentStatus}; skipping screenshot`);
     }

--- a/cdk/src/handlers/shared/linear-verify.ts
+++ b/cdk/src/handlers/shared/linear-verify.ts
@@ -54,7 +54,13 @@ export async function getLinearSecret(secretId: string, forceRefresh = false): P
 
   try {
     const result = await sm.send(new GetSecretValueCommand({ SecretId: secretId }));
-    if (!result.SecretString) {
+    // Treat empty / whitespace-only SecretString as null — an empty secret
+    // must never be used for HMAC, or HMAC('', body) becomes forgeable.
+    // (Same guard as getGitHubWebhookSecret.)
+    if (!result.SecretString || result.SecretString.trim() === '') {
+      logger.error('Linear webhook secret is empty — refusing to use for HMAC', {
+        secret_id: secretId,
+      });
       secretCache.delete(secretId);
       return null;
     }
@@ -101,6 +107,14 @@ export function verifyLinearSignature(
   signature: string,
   body: string,
 ): boolean {
+  // Defense-in-depth: getLinearSecret already filters empty secrets, but
+  // callers like verifyLinearRequestForWorkspace pass secrets from other
+  // sources (per-workspace OAuth bundles) — HMAC('') must always be
+  // rejected or an attacker can forge signatures against a misconfigured
+  // empty secret. (Mirrors verifyGitHubSignature, PR-241 review B2.)
+  if (!webhookSecret || webhookSecret.trim() === '') {
+    return false;
+  }
   const expected = crypto.createHmac('sha256', webhookSecret).update(body).digest('hex');
   try {
     return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signature));

--- a/cdk/test/handlers/shared/agentcore-browser.test.ts
+++ b/cdk/test/handlers/shared/agentcore-browser.test.ts
@@ -263,6 +263,116 @@ describe('captureScreenshot — main-document status check (issue #287)', () => 
     await expect(captureScreenshot('https://preview.example.com')).resolves.toBeDefined();
   });
 
+  test('sub-frame 404 after main-frame 200 → still captures (per-frame attribution)', async () => {
+    // An embedded iframe (ad, widget) can 404 while the page itself is fine.
+    // Before per-frame tracking, "latest Document status wins" let the
+    // sub-frame's 404 overwrite the main frame's 200 → spurious skip.
+    FakeWebSocket.reactions = [
+      () => ({ result: { targetInfos: [{ targetId: 't1', type: 'page', url: 'about:blank' }] } }),
+      () => ({ result: { sessionId: 'flat-sess' } }),
+      () => ({ result: {} }),
+      () => ({ result: {} }),
+      () => ({
+        _response: { result: { frameId: 'frame-1' } },
+        _events: [
+          networkResponseEvent(200, 'frame-1'),
+          networkResponseEvent(404, 'iframe-ads'),
+        ],
+      }),
+      () => ({ result: { data: Buffer.from('PNG-main-ok').toString('base64') } }),
+    ];
+    emitLoadEventFired();
+
+    const png = await captureScreenshot('https://preview.example.com');
+    expect(Buffer.from(png).toString()).toBe('PNG-main-ok');
+  });
+
+  test('sub-frame 200 after main-frame 404 → still throws (per-frame attribution)', async () => {
+    // The inverse race: a 404 page that embeds a 200 sub-frame must not
+    // have its failure masked by the later sub-frame response.
+    FakeWebSocket.reactions = [
+      () => ({ result: { targetInfos: [{ targetId: 't1', type: 'page', url: 'about:blank' }] } }),
+      () => ({ result: { sessionId: 'flat-sess' } }),
+      () => ({ result: {} }),
+      () => ({ result: {} }),
+      () => ({
+        _response: { result: { frameId: 'frame-1' } },
+        _events: [
+          networkResponseEvent(404, 'frame-1'),
+          networkResponseEvent(200, 'iframe-embed'),
+        ],
+      }),
+      () => {
+        throw new Error('captureScreenshot should not run on non-2xx');
+      },
+    ];
+    emitLoadEventFired();
+
+    await expect(captureScreenshot('https://preview.example.com/missing')).rejects.toThrow(
+      /Preview URL returned HTTP 404/,
+    );
+  });
+
+  test('redirect chain on the main frame → final status wins', async () => {
+    // Same frameId re-fires for each hop; the last recorded status is the
+    // final response (here 200 after a 302 hop) → capture proceeds.
+    FakeWebSocket.reactions = [
+      () => ({ result: { targetInfos: [{ targetId: 't1', type: 'page', url: 'about:blank' }] } }),
+      () => ({ result: { sessionId: 'flat-sess' } }),
+      () => ({ result: {} }),
+      () => ({ result: {} }),
+      () => ({
+        _response: { result: { frameId: 'frame-1' } },
+        _events: [
+          networkResponseEvent(302, 'frame-1'),
+          networkResponseEvent(200, 'frame-1'),
+        ],
+      }),
+      () => ({ result: { data: Buffer.from('PNG-redirected').toString('base64') } }),
+    ];
+    emitLoadEventFired();
+
+    const png = await captureScreenshot('https://preview.example.com/old');
+    expect(Buffer.from(png).toString()).toBe('PNG-redirected');
+  });
+
+  test('navigate returns no frameId + single Document status → status still used', async () => {
+    FakeWebSocket.reactions = [
+      () => ({ result: { targetInfos: [{ targetId: 't1', type: 'page', url: 'about:blank' }] } }),
+      () => ({ result: { sessionId: 'flat-sess' } }),
+      () => ({ result: {} }),
+      () => ({ result: {} }),
+      () => ({
+        _response: { result: {} }, // no frameId in the navigate response
+        _events: [networkResponseEvent(503, 'frame-unknown')],
+      }),
+    ];
+    emitLoadEventFired();
+
+    await expect(captureScreenshot('https://preview.example.com/down')).rejects.toThrow(/HTTP 503/);
+  });
+
+  test('navigate returns no frameId + multiple ambiguous Document statuses → captures optimistically', async () => {
+    FakeWebSocket.reactions = [
+      () => ({ result: { targetInfos: [{ targetId: 't1', type: 'page', url: 'about:blank' }] } }),
+      () => ({ result: { sessionId: 'flat-sess' } }),
+      () => ({ result: {} }),
+      () => ({ result: {} }),
+      () => ({
+        _response: { result: {} },
+        _events: [
+          networkResponseEvent(404, 'frame-a'),
+          networkResponseEvent(200, 'frame-b'),
+        ],
+      }),
+      () => ({ result: { data: Buffer.from('PNG-ambiguous').toString('base64') } }),
+    ];
+    emitLoadEventFired();
+
+    const png = await captureScreenshot('https://preview.example.com');
+    expect(Buffer.from(png).toString()).toBe('PNG-ambiguous');
+  });
+
   test('no Network.responseReceived event ever fires → falls through (pre-#287 behaviour)', async () => {
     // Defensive: if some service variant doesn't emit Network events,
     // we still capture optimistically rather than blocking the pipeline.

--- a/cdk/test/handlers/shared/linear-verify.test.ts
+++ b/cdk/test/handlers/shared/linear-verify.test.ts
@@ -1,0 +1,189 @@
+/**
+ *  MIT No Attribution
+ *
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy of
+ *  the Software without restriction, including without limitation the rights to
+ *  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ *  the Software, and to permit persons to whom the Software is furnished to do so.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+import * as crypto from 'crypto';
+
+const smSend = jest.fn();
+jest.mock('@aws-sdk/client-secrets-manager', () => ({
+  SecretsManagerClient: jest.fn(() => ({ send: smSend })),
+  GetSecretValueCommand: jest.fn((input: unknown) => ({ _type: 'GetSecretValue', input })),
+}));
+jest.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: jest.fn(() => ({})),
+}));
+jest.mock('@aws-sdk/lib-dynamodb', () => ({
+  DynamoDBDocumentClient: { from: jest.fn(() => ({ send: jest.fn() })) },
+}));
+
+import {
+  getLinearSecret,
+  invalidateLinearSecretCache,
+  isWebhookTimestampFresh,
+  MAX_WEBHOOK_TIMESTAMP_AGE_MS,
+  verifyLinearRequest,
+  verifyLinearSignature,
+} from '../../../src/handlers/shared/linear-verify';
+
+const SECRET_ID = 'arn:aws:secretsmanager:us-east-1:123:secret:linear-webhook';
+const SECRET_VALUE = 'super-secret';
+
+function signed(body: string, key = SECRET_VALUE): string {
+  return crypto.createHmac('sha256', key).update(body).digest('hex');
+}
+
+describe('verifyLinearSignature', () => {
+  test('accepts a valid signature', () => {
+    const body = '{"action":"create"}';
+    expect(verifyLinearSignature(SECRET_VALUE, signed(body), body)).toBe(true);
+  });
+
+  test('rejects when signature mismatches', () => {
+    const body = '{"action":"create"}';
+    expect(verifyLinearSignature('wrong', signed(body), body)).toBe(false);
+  });
+
+  test('rejects when the body has been tampered', () => {
+    const sig = signed('{"action":"create"}');
+    expect(verifyLinearSignature(SECRET_VALUE, sig, '{"action":"CREATE"}')).toBe(false);
+  });
+
+  test('rejects when provided digest is the wrong byte length (timingSafeEqual would throw)', () => {
+    const body = '{"action":"create"}';
+    expect(verifyLinearSignature(SECRET_VALUE, 'deadbeef', body)).toBe(false);
+  });
+
+  // Empty-secret fail-open guard, mirroring verifyGitHubSignature (B2):
+  // HMAC('', body) is computable by anyone — an empty secret must never
+  // produce an accepted signature.
+  test('rejects empty webhookSecret even with a matching empty-key HMAC', () => {
+    const body = '{"action":"create"}';
+    const forged = crypto.createHmac('sha256', '').update(body).digest('hex');
+    expect(verifyLinearSignature('', forged, body)).toBe(false);
+  });
+
+  test('rejects whitespace-only webhookSecret', () => {
+    const body = '{"action":"create"}';
+    const forged = crypto.createHmac('sha256', '   ').update(body).digest('hex');
+    expect(verifyLinearSignature('   ', forged, body)).toBe(false);
+  });
+});
+
+describe('getLinearSecret', () => {
+  beforeEach(() => {
+    smSend.mockReset();
+    invalidateLinearSecretCache(SECRET_ID);
+  });
+
+  test('returns the secret and caches it', async () => {
+    smSend.mockResolvedValueOnce({ SecretString: SECRET_VALUE });
+    await expect(getLinearSecret(SECRET_ID)).resolves.toBe(SECRET_VALUE);
+    // Second call served from cache — no second SM call.
+    await expect(getLinearSecret(SECRET_ID)).resolves.toBe(SECRET_VALUE);
+    expect(smSend).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns null when SecretString is missing', async () => {
+    smSend.mockResolvedValueOnce({});
+    await expect(getLinearSecret(SECRET_ID)).resolves.toBeNull();
+  });
+
+  test('returns null when SecretString is the empty string', async () => {
+    smSend.mockResolvedValueOnce({ SecretString: '' });
+    await expect(getLinearSecret(SECRET_ID)).resolves.toBeNull();
+  });
+
+  test('returns null when SecretString is whitespace-only', async () => {
+    smSend.mockResolvedValueOnce({ SecretString: '   ' });
+    await expect(getLinearSecret(SECRET_ID)).resolves.toBeNull();
+  });
+
+  test('returns null on ResourceNotFoundException', async () => {
+    smSend.mockRejectedValueOnce(Object.assign(new Error('nope'), { name: 'ResourceNotFoundException' }));
+    await expect(getLinearSecret(SECRET_ID)).resolves.toBeNull();
+  });
+
+  test('rethrows other Secrets Manager errors', async () => {
+    smSend.mockRejectedValueOnce(Object.assign(new Error('throttled'), { name: 'ThrottlingException' }));
+    await expect(getLinearSecret(SECRET_ID)).rejects.toThrow('throttled');
+  });
+
+  test('forceRefresh bypasses the cache', async () => {
+    smSend.mockResolvedValueOnce({ SecretString: 'old' });
+    smSend.mockResolvedValueOnce({ SecretString: 'new' });
+    await expect(getLinearSecret(SECRET_ID)).resolves.toBe('old');
+    await expect(getLinearSecret(SECRET_ID, true)).resolves.toBe('new');
+    expect(smSend).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('verifyLinearRequest', () => {
+  beforeEach(() => {
+    smSend.mockReset();
+    invalidateLinearSecretCache(SECRET_ID);
+  });
+
+  test('verifies against the cached secret', async () => {
+    smSend.mockResolvedValueOnce({ SecretString: SECRET_VALUE });
+    const body = '{"action":"create"}';
+    await expect(verifyLinearRequest(SECRET_ID, signed(body), body)).resolves.toBe(true);
+  });
+
+  test('re-fetches once after rotation and verifies with the fresh secret', async () => {
+    const body = '{"action":"create"}';
+    smSend.mockResolvedValueOnce({ SecretString: 'rotated-out' });
+    smSend.mockResolvedValueOnce({ SecretString: SECRET_VALUE });
+    await expect(verifyLinearRequest(SECRET_ID, signed(body), body)).resolves.toBe(true);
+    expect(smSend).toHaveBeenCalledTimes(2);
+  });
+
+  test('returns false when the fresh secret matches the cached one (no rotation)', async () => {
+    const body = '{"action":"create"}';
+    smSend.mockResolvedValueOnce({ SecretString: 'wrong' });
+    smSend.mockResolvedValueOnce({ SecretString: 'wrong' });
+    await expect(verifyLinearRequest(SECRET_ID, signed(body), body)).resolves.toBe(false);
+  });
+
+  test('returns false when the stored secret is empty (end-to-end fail-closed)', async () => {
+    const body = '{"action":"create"}';
+    // An attacker who knows the secret is empty would send HMAC('', body).
+    const forged = crypto.createHmac('sha256', '').update(body).digest('hex');
+    smSend.mockResolvedValue({ SecretString: '' });
+    await expect(verifyLinearRequest(SECRET_ID, forged, body)).resolves.toBe(false);
+  });
+});
+
+describe('isWebhookTimestampFresh', () => {
+  test('accepts a current timestamp', () => {
+    expect(isWebhookTimestampFresh(Date.now())).toBe(true);
+  });
+
+  test('rejects a timestamp older than the replay window', () => {
+    expect(isWebhookTimestampFresh(Date.now() - MAX_WEBHOOK_TIMESTAMP_AGE_MS - 1000)).toBe(false);
+  });
+
+  test('rejects a far-future timestamp', () => {
+    expect(isWebhookTimestampFresh(Date.now() + MAX_WEBHOOK_TIMESTAMP_AGE_MS + 1000)).toBe(false);
+  });
+
+  test('rejects undefined and non-finite values', () => {
+    expect(isWebhookTimestampFresh(undefined)).toBe(false);
+    expect(isWebhookTimestampFresh(NaN)).toBe(false);
+    expect(isWebhookTimestampFresh(Infinity)).toBe(false);
+  });
+});

--- a/cli/src/api-client.ts
+++ b/cli/src/api-client.ts
@@ -19,7 +19,7 @@
 
 import { getAuthToken } from './auth';
 import { loadConfig } from './config';
-import { debug } from './debug';
+import { debug, redactSensitive } from './debug';
 import { ApiError, CliError } from './errors';
 import {
   ApprovalRequest,
@@ -73,7 +73,7 @@ export class ApiClient {
 
     debug(`${method} ${url}`);
     if (body) {
-      debug(`Request body: ${JSON.stringify(body)}`);
+      debug(`Request body: ${JSON.stringify(redactSensitive(body))}`);
     }
 
     const res = await fetch(url, {
@@ -98,7 +98,9 @@ export class ApiClient {
     }
 
     if (jsonParseOk) {
-      debug(`Response body: ${JSON.stringify(json)}`);
+      // Redact secret-bearing fields (e.g. the one-time webhook `secret`) —
+      // verbose output ends up in scrollback / CI logs.
+      debug(`Response body: ${JSON.stringify(redactSensitive(json))}`);
     }
 
     if (!res.ok) {

--- a/cli/src/debug.ts
+++ b/cli/src/debug.ts
@@ -35,3 +35,38 @@ export function debug(message: string): void {
     console.error(`[DEBUG] ${message}`);
   }
 }
+
+/**
+ * Field names whose values must never appear in `--verbose` output.
+ * Webhook creation returns a one-time `secret`; OAuth flows carry
+ * `access_token` / `refresh_token`. Verbose logs land in scrollback and
+ * CI logs, which outlive the "shown once" guarantee of those values.
+ */
+const SENSITIVE_FIELDS = new Set([
+  'secret',
+  'access_token',
+  'refresh_token',
+  'id_token',
+  'client_secret',
+  'authorization',
+  'password',
+  'token',
+]);
+
+/**
+ * Deep-copy a JSON-shaped value with sensitive field values replaced by
+ * `[REDACTED]`, for safe debug logging of request/response bodies.
+ */
+export function redactSensitive(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(redactSensitive);
+  }
+  if (value !== null && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = SENSITIVE_FIELDS.has(key.toLowerCase()) ? '[REDACTED]' : redactSensitive(val);
+    }
+    return out;
+  }
+  return value;
+}

--- a/cli/test/debug.test.ts
+++ b/cli/test/debug.test.ts
@@ -1,0 +1,91 @@
+/**
+ *  MIT No Attribution
+ *
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy of
+ *  the Software without restriction, including without limitation the rights to
+ *  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ *  the Software, and to permit persons to whom the Software is furnished to do so.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+import { debug, isVerbose, redactSensitive, setVerbose } from '../src/debug';
+
+describe('redactSensitive', () => {
+  test('redacts the one-time webhook secret in a response body', () => {
+    const body = {
+      webhook_id: 'wh-1',
+      secret: 'whsec_supersecret',
+      url: 'https://api.example.com/webhooks/wh-1',
+    };
+    expect(redactSensitive(body)).toEqual({
+      webhook_id: 'wh-1',
+      secret: '[REDACTED]',
+      url: 'https://api.example.com/webhooks/wh-1',
+    });
+  });
+
+  test('redacts nested and array-wrapped sensitive fields', () => {
+    const body = {
+      data: [{ access_token: 'tok-1', name: 'a' }, { refresh_token: 'tok-2' }],
+      oauth: { client_secret: 'cs-1', client_id: 'ci-1' },
+    };
+    expect(redactSensitive(body)).toEqual({
+      data: [{ access_token: '[REDACTED]', name: 'a' }, { refresh_token: '[REDACTED]' }],
+      oauth: { client_secret: '[REDACTED]', client_id: 'ci-1' },
+    });
+  });
+
+  test('matches field names case-insensitively', () => {
+    expect(redactSensitive({ Authorization: 'Bearer abc' })).toEqual({
+      Authorization: '[REDACTED]',
+    });
+  });
+
+  test('does not redact non-sensitive fields like next_token', () => {
+    const body = { next_token: 'page-cursor', items: [] };
+    expect(redactSensitive(body)).toEqual({ next_token: 'page-cursor', items: [] });
+  });
+
+  test('passes through primitives and null unchanged', () => {
+    expect(redactSensitive('plain')).toBe('plain');
+    expect(redactSensitive(42)).toBe(42);
+    expect(redactSensitive(null)).toBeNull();
+  });
+
+  test('does not mutate the input object', () => {
+    const body = { secret: 'keep-me' };
+    redactSensitive(body);
+    expect(body.secret).toBe('keep-me');
+  });
+});
+
+describe('debug / setVerbose', () => {
+  afterEach(() => {
+    setVerbose(false);
+    jest.restoreAllMocks();
+  });
+
+  test('debug is silent when verbose is off', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    setVerbose(false);
+    debug('hidden');
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  test('debug writes to stderr when verbose is on', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    setVerbose(true);
+    expect(isVerbose()).toBe(true);
+    debug('shown');
+    expect(spy).toHaveBeenCalledWith('[DEBUG] shown');
+  });
+});

--- a/docs/design/ARCHITECTURE.md
+++ b/docs/design/ARCHITECTURE.md
@@ -47,11 +47,11 @@ Blueprints configure how the orchestrator executes steps for each repo: compute 
 
 Different tasks and repos may benefit from different models. The `model_id` field in the Blueprint config allows per-repo overrides:
 
-| Task type | Suggested model | Model ID (as wired in `cdk/src/stacks/agent.ts`) | Rationale |
+| Workflow | Suggested model | Model ID (as wired in `cdk/src/stacks/agent.ts`) | Rationale |
 |---|---|---|---|
-| `new_task` | Claude Sonnet 4 | `anthropic.claude-sonnet-4-6` | Good balance of quality and cost |
-| `pr_iteration` | Claude Sonnet 4 | `anthropic.claude-sonnet-4-6` | Needs to understand review feedback and make code changes |
-| `pr_review` | Claude Haiku | `anthropic.claude-haiku-4-5-20251001-v1:0` | Fast and cheap - review is read-only analysis |
+| `coding/new-task-v1` | Claude Sonnet 4 | `anthropic.claude-sonnet-4-6` | Good balance of quality and cost |
+| `coding/pr-iteration-v1` | Claude Sonnet 4 | `anthropic.claude-sonnet-4-6` | Needs to understand review feedback and make code changes |
+| `coding/pr-review-v1` | Claude Haiku | `anthropic.claude-haiku-4-5-20251001-v1:0` | Fast and cheap - review is read-only analysis |
 | Complex/critical repos | Claude Opus 4 | `anthropic.claude-opus-4-20250514-v1:0` | Highest quality, opt-in per repo |
 
 ## Cost model

--- a/docs/design/ORCHESTRATOR.md
+++ b/docs/design/ORCHESTRATOR.md
@@ -178,13 +178,13 @@ Runs as a distinct top-level step (`pre-flight` in `orchestrate-task.ts`, via `r
 
 ### Step 3: Context hydration
 
-Assembles the agent's user prompt and transitions the task to `HYDRATING`. The implementation lives in `context-hydration.ts`. What it does, by task type:
+Assembles the agent's user prompt and transitions the task to `HYDRATING`. The implementation lives in `context-hydration.ts`. What it does, by resolved workflow:
 
-**`new_task`:** Fetches the GitHub issue (title, body, comments) if `issue_number` is set, loads memory from past tasks, and combines everything with the user's task description.
+**Non-PR workflows (e.g. `coding/new-task-v1`):** Fetches the GitHub issue (title, body, comments) if `issue_number` is set, loads memory from past tasks, and combines everything with the user's task description.
 
-**`pr_iteration` / `pr_review`:** Fetches PR metadata, conversation comments, changed files (REST), and inline review comments (GraphQL, resolved threads filtered out) in four parallel calls. Extracts `head_ref` and `base_ref` for branch resolution.
+**PR workflows (`coding/pr-iteration-v1` / `coding/pr-review-v1`):** Fetches PR metadata, conversation comments, changed files (REST), and inline review comments (GraphQL, resolved threads filtered out) in four parallel calls. Extracts `head_ref` and `base_ref` for branch resolution.
 
-Regardless of task type, the assembled prompt is screened through Amazon Bedrock Guardrails for prompt injection (fail-closed: unscreened content never reaches the agent). A token budget (default 100K tokens, ~4 chars/token heuristic) trims oldest comments first when exceeded.
+Regardless of workflow, the assembled prompt is screened through Amazon Bedrock Guardrails for prompt injection (fail-closed: unscreened content never reaches the agent). A token budget (default 100K tokens, ~4 chars/token heuristic) trims oldest comments first when exceeded.
 
 ### Step 4: Session start
 
@@ -383,18 +383,16 @@ Three DynamoDB tables back the orchestrator: one for task state, one for the aud
 | `user_id` | String | Cognito sub |
 | `status` | String | Current state |
 | `repo` | String | `owner/repo` |
-| `task_type` | String | `new_task`, `pr_iteration`, or `pr_review` |
+| `workflow_ref` | String? | Workflow reference as submitted (e.g. `coding/new-task-v1`); default when absent |
+| `resolved_workflow` | Map | Resolved workflow snapshot `{id, version}` — replaces the former `task_type` enum (#248) |
 | `issue_number` | Number? | GitHub issue number |
-| `pr_number` | Number? | PR number (required for PR task types) |
+| `pr_number` | Number? | PR number (required for PR workflows) |
 | `task_description` | String? | Free-text description |
 | `branch_name` | String | `bgagent/{task_id}/{slug}` for new tasks; PR's `head_ref` for PR tasks |
 | `session_id` | String? | AgentCore session ID |
 | `execution_id` | String? | Durable execution ID |
 | `pr_url` | String? | PR URL (set during finalization) |
 | `error_message` | String? | Error reason if FAILED |
-| `error_code` | String? | Machine-readable error code (e.g. `SESSION_START_FAILED`) |
-
-> **Derived field:** `error_classification` is not stored in DynamoDB. It is computed at API response time by passing `error_message` through the runtime error classifier (`error-classifier.ts`). This returns a structured object with `category` (auth/network/concurrency/compute/agent/guardrail/config/timeout/unknown), `title`, `description`, `remedy`, and `retryable` flag. The derived-field pattern means classifier updates take effect immediately for all existing tasks without data migration.
 | `max_turns` | Number? | Turn limit (per-task overrides per-repo default) |
 | `max_budget_usd` | Number? | Cost ceiling (per-task overrides per-repo default) |
 | `model_id` | String? | Foundation model ID |
@@ -404,6 +402,8 @@ Three DynamoDB tables back the orchestrator: one for task state, one for the aud
 | `duration_s` | Number? | Total duration |
 | `ttl` | Number? | DynamoDB TTL (default: created_at + 90 days) |
 | `created_at` / `updated_at` | String | ISO 8601 timestamps |
+
+> **Derived field:** `error_classification` is not stored in DynamoDB. It is computed at API response time by passing `error_message` through the runtime error classifier (`error-classifier.ts`). This returns a structured object with `category` (auth/network/concurrency/compute/agent/guardrail/config/timeout/unknown), `title`, `description`, `remedy`, and `retryable` flag. The derived-field pattern means classifier updates take effect immediately for all existing tasks without data migration.
 
 **GSIs:** `UserStatusIndex` (PK: `user_id`, SK: `status#created_at`), `StatusIndex` (PK: `status`, SK: `created_at`), `IdempotencyIndex` (PK: `idempotency_key`, sparse).
 

--- a/docs/src/content/docs/architecture/Architecture.md
+++ b/docs/src/content/docs/architecture/Architecture.md
@@ -51,11 +51,11 @@ Blueprints configure how the orchestrator executes steps for each repo: compute 
 
 Different tasks and repos may benefit from different models. The `model_id` field in the Blueprint config allows per-repo overrides:
 
-| Task type | Suggested model | Model ID (as wired in `cdk/src/stacks/agent.ts`) | Rationale |
+| Workflow | Suggested model | Model ID (as wired in `cdk/src/stacks/agent.ts`) | Rationale |
 |---|---|---|---|
-| `new_task` | Claude Sonnet 4 | `anthropic.claude-sonnet-4-6` | Good balance of quality and cost |
-| `pr_iteration` | Claude Sonnet 4 | `anthropic.claude-sonnet-4-6` | Needs to understand review feedback and make code changes |
-| `pr_review` | Claude Haiku | `anthropic.claude-haiku-4-5-20251001-v1:0` | Fast and cheap - review is read-only analysis |
+| `coding/new-task-v1` | Claude Sonnet 4 | `anthropic.claude-sonnet-4-6` | Good balance of quality and cost |
+| `coding/pr-iteration-v1` | Claude Sonnet 4 | `anthropic.claude-sonnet-4-6` | Needs to understand review feedback and make code changes |
+| `coding/pr-review-v1` | Claude Haiku | `anthropic.claude-haiku-4-5-20251001-v1:0` | Fast and cheap - review is read-only analysis |
 | Complex/critical repos | Claude Opus 4 | `anthropic.claude-opus-4-20250514-v1:0` | Highest quality, opt-in per repo |
 
 ## Cost model

--- a/docs/src/content/docs/architecture/Orchestrator.md
+++ b/docs/src/content/docs/architecture/Orchestrator.md
@@ -182,13 +182,13 @@ Runs as a distinct top-level step (`pre-flight` in `orchestrate-task.ts`, via `r
 
 ### Step 3: Context hydration
 
-Assembles the agent's user prompt and transitions the task to `HYDRATING`. The implementation lives in `context-hydration.ts`. What it does, by task type:
+Assembles the agent's user prompt and transitions the task to `HYDRATING`. The implementation lives in `context-hydration.ts`. What it does, by resolved workflow:
 
-**`new_task`:** Fetches the GitHub issue (title, body, comments) if `issue_number` is set, loads memory from past tasks, and combines everything with the user's task description.
+**Non-PR workflows (e.g. `coding/new-task-v1`):** Fetches the GitHub issue (title, body, comments) if `issue_number` is set, loads memory from past tasks, and combines everything with the user's task description.
 
-**`pr_iteration` / `pr_review`:** Fetches PR metadata, conversation comments, changed files (REST), and inline review comments (GraphQL, resolved threads filtered out) in four parallel calls. Extracts `head_ref` and `base_ref` for branch resolution.
+**PR workflows (`coding/pr-iteration-v1` / `coding/pr-review-v1`):** Fetches PR metadata, conversation comments, changed files (REST), and inline review comments (GraphQL, resolved threads filtered out) in four parallel calls. Extracts `head_ref` and `base_ref` for branch resolution.
 
-Regardless of task type, the assembled prompt is screened through Amazon Bedrock Guardrails for prompt injection (fail-closed: unscreened content never reaches the agent). A token budget (default 100K tokens, ~4 chars/token heuristic) trims oldest comments first when exceeded.
+Regardless of workflow, the assembled prompt is screened through Amazon Bedrock Guardrails for prompt injection (fail-closed: unscreened content never reaches the agent). A token budget (default 100K tokens, ~4 chars/token heuristic) trims oldest comments first when exceeded.
 
 ### Step 4: Session start
 
@@ -387,18 +387,16 @@ Three DynamoDB tables back the orchestrator: one for task state, one for the aud
 | `user_id` | String | Cognito sub |
 | `status` | String | Current state |
 | `repo` | String | `owner/repo` |
-| `task_type` | String | `new_task`, `pr_iteration`, or `pr_review` |
+| `workflow_ref` | String? | Workflow reference as submitted (e.g. `coding/new-task-v1`); default when absent |
+| `resolved_workflow` | Map | Resolved workflow snapshot `{id, version}` — replaces the former `task_type` enum (#248) |
 | `issue_number` | Number? | GitHub issue number |
-| `pr_number` | Number? | PR number (required for PR task types) |
+| `pr_number` | Number? | PR number (required for PR workflows) |
 | `task_description` | String? | Free-text description |
 | `branch_name` | String | `bgagent/{task_id}/{slug}` for new tasks; PR's `head_ref` for PR tasks |
 | `session_id` | String? | AgentCore session ID |
 | `execution_id` | String? | Durable execution ID |
 | `pr_url` | String? | PR URL (set during finalization) |
 | `error_message` | String? | Error reason if FAILED |
-| `error_code` | String? | Machine-readable error code (e.g. `SESSION_START_FAILED`) |
-
-> **Derived field:** `error_classification` is not stored in DynamoDB. It is computed at API response time by passing `error_message` through the runtime error classifier (`error-classifier.ts`). This returns a structured object with `category` (auth/network/concurrency/compute/agent/guardrail/config/timeout/unknown), `title`, `description`, `remedy`, and `retryable` flag. The derived-field pattern means classifier updates take effect immediately for all existing tasks without data migration.
 | `max_turns` | Number? | Turn limit (per-task overrides per-repo default) |
 | `max_budget_usd` | Number? | Cost ceiling (per-task overrides per-repo default) |
 | `model_id` | String? | Foundation model ID |
@@ -408,6 +406,8 @@ Three DynamoDB tables back the orchestrator: one for task state, one for the aud
 | `duration_s` | Number? | Total duration |
 | `ttl` | Number? | DynamoDB TTL (default: created_at + 90 days) |
 | `created_at` / `updated_at` | String | ISO 8601 timestamps |
+
+> **Derived field:** `error_classification` is not stored in DynamoDB. It is computed at API response time by passing `error_message` through the runtime error classifier (`error-classifier.ts`). This returns a structured object with `category` (auth/network/concurrency/compute/agent/guardrail/config/timeout/unknown), `title`, `description`, `remedy`, and `retryable` flag. The derived-field pattern means classifier updates take effect immediately for all existing tasks without data migration.
 
 **GSIs:** `UserStatusIndex` (PK: `user_id`, SK: `status#created_at`), `StatusIndex` (PK: `status`, SK: `created_at`), `IdempotencyIndex` (PK: `idempotency_key`, sparse).
 


### PR DESCRIPTION
Fixes multiple findings

1. Auto-approve / Mergify governance gap — .github/workflows/auto-approve.yml now triggers on labeled only (was: every push/synchronize), checks the event's label is literally auto-approve, and skips fork-head PRs. .mergify.yml gained
  a dismiss_reviews rule so any new push invalidates stale approvals; re-approval requires removing and re-adding the label. zizmor reports no findings on the updated workflow.

  2. UTC timezone bug in approval-gate lifetime math — agent/src/hooks.py now parses TASK_STARTED_AT with tzinfo=UTC before calling .timestamp(). Added a TestRemainingMaxlifetime suite (4 tests) in agent/tests/test_hooks.py, including
  one that sets TZ=America/New_York to prove the regression would be caught.

  3. PAT no longer persisted in .git/config — agent/src/repo.py sets the origin remote to the plain https URL and configures credential.helper = !gh auth git-credential, which resolves the token at push time from the GH_TOKEN env var
  the pipeline already exports before setup_repo(). The token never touches disk. Also widened agent/src/output_scanner.py: GitHub token regex now matches 36+ chars and the ghr_ prefix, and a new GITHUB_URL_TOKEN pattern catches
  x-access-token:…@ URLs echoed in tool output (2 new tests).

  4. Linear webhook empty-secret forgery — cdk/src/handlers/shared/linear-verify.ts: verifyLinearSignature rejects empty/whitespace secrets (critical for the per-workspace path, whose secrets come from OAuth bundles, not
  getLinearSecret), and getLinearSecret treats whitespace-only SecretString as null — mirroring the hardened GitHub verifier. Created the previously missing cdk/test/handlers/shared/linear-verify.test.ts with 21 tests covering
  signatures, caching, rotation re-fetch, replay window, and the forgery scenario end-to-end.

  5. Screenshot frame-attribution race — cdk/src/handlers/shared/agentcore-browser.ts now records Document response statuses per frameId in the single message listener (the duplicate listener and its double JSON.parse are gone), and
  resolves the main frame's status after load using the frameId from Page.navigate. Events arriving before navigate resolves are no longer lost or misattributed; an unambiguous single status is used when navigate returns no frameId, and
  ambiguous multi-frame cases fall back to optimistic capture. Added 5 race-scenario tests (sub-frame 404 after main 200, the inverse, redirect chains, missing frameId).

  6. CLI --verbose secret leak — new redactSensitive() in cli/src/debug.ts deep-redacts secret, access_token, refresh_token, client_secret, authorization, etc. before request/response bodies are debug-logged in cli/src/api-client.ts.
  New cli/test/debug.test.ts (8 tests) covers the webhook-secret case, nesting, case-insensitivity, and non-mutation.

  7. Stale task_type contract in design docs — docs/design/ORCHESTRATOR.md Tasks table now documents workflow_ref/resolved_workflow (the task_type and never-implemented error_code rows are gone), the mid-table blockquote that broke
  rendering was moved below the table, and the hydration prose is keyed by workflow. docs/design/ARCHITECTURE.md model table and the AGENTS.md types.ts description now use workflow IDs. Starlight mirrors regenerated via
  sync-starlight.mjs.

  Verification: agent — 1016 tests pass (mise run quality, 76.3% coverage); cdk — compile clean, 2011 tests pass; cli — full build (compile + 324 tests + lint) passes; zizmor clean.

#### Area

<!-- Check all that apply -->

- [x] `cdk` — infrastructure, handlers, constructs
- [x] `agent` — Python runtime / Docker image
- [x] `cli` — `bgagent` client
- [x] `docs` — guides or design sources (`docs/guides/`, `docs/design/`)
- [x] `tooling` — root `mise.toml`, scripts, CI workflows

Tip: [AGENTS.md](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/blob/main/AGENTS.md) lists where to edit and which tests to extend.

#### Related

<!-- Issue #, Vulnerability, References if available:* -->

#### Changes

<!-- Description of changes:* -->

#### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/blob/main/LICENSE).
