### PR TITLE
fix(ci): scope merge_group gitleaks scan to the merge-group commit range

### DIFF
--- a/.github/workflows/security-pr.yml
+++ b/.github/workflows/security-pr.yml
@@ -54,6 +54,8 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MG_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
         run: |
           set -euo pipefail
           case "$EVENT_NAME" in
@@ -61,9 +63,15 @@ jobs:
               # Scan exactly the commits this PR introduces.
               echo "range=${PR_BASE_SHA}..${PR_HEAD_SHA}" >> "$GITHUB_OUTPUT"
               ;;
-            merge_group|workflow_dispatch|*)
-              # In the merge queue (and on manual dispatch) there is no PR diff to
-              # scope to; scan the full reachable history as a backstop.
+            merge_group)
+              # Scan exactly the commits this merge group introduces (#336).
+              # An empty range here would fall back to full history, which
+              # re-reports the historical #313 findings and deadlocks the queue.
+              echo "range=${MG_BASE_SHA}..${MG_HEAD_SHA}" >> "$GITHUB_OUTPUT"
+              ;;
+            workflow_dispatch|*)
+              # On manual dispatch there is no PR diff to scope to; scan the
+              # full reachable history as a backstop.
               echo "range=" >> "$GITHUB_OUTPUT"
               ;;
           esac


### PR DESCRIPTION
## Summary

Closes #336 (P0). Unblocks the merge queue (currently deadlocking PR #334).

On `merge_group` events, the `Resolve PR commit range` step in `security-pr.yml` set `GITLEAKS_RANGE` to empty, so the "range" scan fell back to the **full reachable history** (335 commits). The full history re-reports the historical #313 `aws-account-id` findings, so the required **Secrets, deps, and workflow scan** check fails for every PR entering the merge queue — see [job 81132907683](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/actions/runs/27446609941/job/81132907683):

```
gitleaks git . --no-banner --redact --log-opts=""
INF 335 commits scanned.
WRN leaks found: 2
ERROR task failed
```

## Fix

Add a dedicated `merge_group` case that scopes the scan to exactly the commits being merged, using the event payload (same source `build.yml` already uses):

```
range=${{ github.event.merge_group.base_sha }}..${{ github.event.merge_group.head_sha }}
```

- `pull_request` behaviour unchanged (`base.sha..head.sha`)
- `workflow_dispatch` keeps the full-history backstop (manual run, not a required check)

## Verification

- `mise run security:gh-actions` (zizmor): no findings
- Draft → the real test is this PR's own merge-queue run; the `pull_request` run of security-pr on this PR exercises the unchanged path

## Note

Pushed as a draft without waiting for the full local build, per maintainer direction — this is a CI-only YAML change and the queue is blocked.