### PR TITLE
perf(test): skip redundant jest type-check via isolatedModules (#357)

### DIFF
--- a/cdk/package.json
+++ b/cdk/package.json
@@ -122,7 +122,7 @@
       "^.+\\.[t]sx?$": [
         "ts-jest",
         {
-          "tsconfig": "tsconfig.dev.json"
+          "tsconfig": "tsconfig.jest.json"
         }
       ]
     }

--- a/cdk/tsconfig.jest.json
+++ b/cdk/tsconfig.jest.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.dev.json",
+  "compilerOptions": {
+    "isolatedModules": true,
+    "module": "CommonJS",
+    "moduleResolution": "Node"
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -93,7 +93,7 @@
       "^.+\\.[t]sx?$": [
         "ts-jest",
         {
-          "tsconfig": "tsconfig.dev.json"
+          "tsconfig": "tsconfig.jest.json"
         }
       ]
     }

--- a/cli/tsconfig.jest.json
+++ b/cli/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.dev.json",
+  "compilerOptions": {
+    "isolatedModules": true
+  }
+}


### PR DESCRIPTION
## What

Cut the CI build's dominant cost — the CDK Jest suite — by **skipping the redundant type-check** that `ts-jest` performs on every file during transform. Type-checking is already done authoritatively by `//cdk:compile` (`tsc --build`) in the same `mise run build` DAG, so paying for it again in `//cdk:test` is pure duplicated work.

This is **one of two approaches** explored under #357 (the other is `@swc/jest`). This branch is the **`ts-jest` + `isolatedModules`** path: same ~2× speedup, **zero test-file changes**.

Closes part of #357 (see issue for full profiling + the swc comparison).

## Why this is the bottleneck

From merge_group run `27594431591` (4-core runner): the `build` step is ~710s of the ~14 min job, and `//cdk:test` alone is **648.9s (~91%)** of it. Everything else finishes in the first ~2 min and idles. (Full breakdown on #357.)

## Change

- `cdk/tsconfig.jest.json` (new) — extends `tsconfig.dev.json`, adds `isolatedModules:true` + `module:CommonJS` + `moduleResolution:Node`.
- `cli/tsconfig.jest.json` (new) — extends `tsconfig.dev.json`, adds `isolatedModules:true` (CLI is already CommonJS).
- `cdk/package.json`, `cli/package.json` — point the Jest `transform` at the new `tsconfig.jest.json`.

**Why the dedicated jest tsconfig instead of just flipping the transform option:** ts-jest's own `isolatedModules` option is deprecated in v30; the supported path is `isolatedModules` in tsconfig. And `cdk/tsconfig.dev.json` is `module:NodeNext`, which leaves dynamic `import()` as native ESM — that breaks jest's VM (`ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG`) in the 4 handlers that lazy-`import()` (`confirm-uploads`, `attachment-screening`, …). Forcing `module:CommonJS` in the jest-only tsconfig downlevels `import()` → `require()` and keeps prod/synth tsconfigs untouched.

## Results (local, 8-core)

| | before (ts-jest) | after (isolatedModules) | Δ |
|---|---|---|---|
| `//cdk:test` | 314s | **155s** | ~2× |
| `//cli:test` | 104s | **4s** | type-check was ~all of CLI cost |

- **2041 CDK + 355 CLI tests pass.**
- Coverage thresholds unchanged and met (CDK lines 92.1 ≥ 91, branches 82.9 ≥ 82, funcs 95.1 ≥ 94).
- `//cdk:compile` / `//cli:compile` unchanged — **type-safety gate intact**.

Extrapolated to the 4-core CI runner (baseline 649s), `//cdk:test` should land ~300–320s, taking the overall build from ~14 min toward ~7–9 min.

## Type-safety note

Tests no longer fail on type errors (they transpile-only). This is intentional: `//cdk:compile` (`tsc --build`) is the type-check gate and runs in the same build DAG, so a type error still fails the build.

## Draft / comparison

Opened as **draft** for side-by-side comparison with the `@swc/jest` branch on #357. Compare CI `//cdk:test` timing and diff footprint before choosing one.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
