### PR TITLE
fix(cdk): allow-list JiraIntegration* secret in bootstrap policy (#402)

### DIFF
--- a/cdk/bootstrap/bootstrap-template.yaml
+++ b/cdk/bootstrap/bootstrap-template.yaml
@@ -1129,6 +1129,7 @@ Resources:
               - arn:aws:secretsmanager:*:*:secret:GitHubTokenSecret*
               - arn:aws:secretsmanager:*:*:secret:SlackIntegration*
               - arn:aws:secretsmanager:*:*:secret:LinearIntegration*
+              - arn:aws:secretsmanager:*:*:secret:JiraIntegration*
               - arn:aws:secretsmanager:*:*:secret:GitHubScreenshot*
               - arn:aws:secretsmanager:*:*:secret:bgagent/*
             Sid: SecretsManager

--- a/cdk/bootstrap/policies/application.json
+++ b/cdk/bootstrap/policies/application.json
@@ -205,6 +205,7 @@
         "arn:aws:secretsmanager:*:*:secret:GitHubTokenSecret*",
         "arn:aws:secretsmanager:*:*:secret:SlackIntegration*",
         "arn:aws:secretsmanager:*:*:secret:LinearIntegration*",
+        "arn:aws:secretsmanager:*:*:secret:JiraIntegration*",
         "arn:aws:secretsmanager:*:*:secret:GitHubScreenshot*",
         "arn:aws:secretsmanager:*:*:secret:bgagent/*"
       ],

--- a/cdk/src/bootstrap/policies/application.ts
+++ b/cdk/src/bootstrap/policies/application.ts
@@ -246,6 +246,7 @@ export function applicationPolicy(): iam.PolicyDocument {
           'arn:aws:secretsmanager:*:*:secret:GitHubTokenSecret*',
           'arn:aws:secretsmanager:*:*:secret:SlackIntegration*',
           'arn:aws:secretsmanager:*:*:secret:LinearIntegration*',
+          'arn:aws:secretsmanager:*:*:secret:JiraIntegration*',
           'arn:aws:secretsmanager:*:*:secret:GitHubScreenshot*',
           'arn:aws:secretsmanager:*:*:secret:bgagent/*',
         ],

--- a/cdk/test/bootstrap/policies.test.ts
+++ b/cdk/test/bootstrap/policies.test.ts
@@ -148,6 +148,38 @@ describe('IaCRole-ABCA-Application', () => {
       ]),
     );
   });
+
+  it('SecretsManager statement allow-lists a secret pattern for every integration that creates a secret', () => {
+    // Regression guard for #402: each integration construct that creates a
+    // Secrets Manager secret (GitHub token, Slack, Linear, Jira, GitHub
+    // screenshot) names it after its construct id, so the CFN exec role's
+    // scoped CreateSecret allow-list must carry a matching prefix. A missing
+    // pattern is invisible to the service-prefix check above (it's still
+    // `secretsmanager:`) but fails the deploy with AccessDenied at
+    // CreateSecret time. Jira shipped without its pattern; this locks the
+    // contract so the next integration can't repeat it.
+    const resolvedDoc = stack.resolve(doc);
+    const statements = resolvedDoc.Statement as Array<{
+      Sid: string;
+      Resource?: string | string[];
+    }>;
+    const secretsStatement = statements.find((s) => s.Sid === 'SecretsManager');
+    expect(secretsStatement).toBeDefined();
+
+    const resources = Array.isArray(secretsStatement!.Resource)
+      ? secretsStatement!.Resource
+      : [secretsStatement!.Resource];
+
+    for (const prefix of [
+      'GitHubTokenSecret',
+      'SlackIntegration',
+      'LinearIntegration',
+      'JiraIntegration',
+      'GitHubScreenshot',
+    ]) {
+      expect(resources).toContain(`arn:aws:secretsmanager:*:*:secret:${prefix}*`);
+    }
+  });
 });
 
 describe('IaCRole-ABCA-Observability', () => {

--- a/docs/design/DEPLOYMENT_ROLES.md
+++ b/docs/design/DEPLOYMENT_ROLES.md
@@ -473,6 +473,7 @@ DynamoDB tables, Lambda functions, API Gateway, Cognito, WAFv2, EventBridge, SQS
         "arn:aws:secretsmanager:*:*:secret:GitHubTokenSecret*",
         "arn:aws:secretsmanager:*:*:secret:SlackIntegration*",
         "arn:aws:secretsmanager:*:*:secret:LinearIntegration*",
+        "arn:aws:secretsmanager:*:*:secret:JiraIntegration*",
         "arn:aws:secretsmanager:*:*:secret:GitHubScreenshot*",
         "arn:aws:secretsmanager:*:*:secret:bgagent/*"
       ]

--- a/docs/src/content/docs/architecture/Deployment-roles.md
+++ b/docs/src/content/docs/architecture/Deployment-roles.md
@@ -477,6 +477,7 @@ DynamoDB tables, Lambda functions, API Gateway, Cognito, WAFv2, EventBridge, SQS
         "arn:aws:secretsmanager:*:*:secret:GitHubTokenSecret*",
         "arn:aws:secretsmanager:*:*:secret:SlackIntegration*",
         "arn:aws:secretsmanager:*:*:secret:LinearIntegration*",
+        "arn:aws:secretsmanager:*:*:secret:JiraIntegration*",
         "arn:aws:secretsmanager:*:*:secret:GitHubScreenshot*",
         "arn:aws:secretsmanager:*:*:secret:bgagent/*"
       ]


### PR DESCRIPTION
## Summary

A fresh `mise //cdk:bootstrap` + `mise //cdk:deploy` of current `main` rolls back during stack creation:

```
cdk-hnb659fds-cfn-exec-role is not authorized to perform secretsmanager:CreateSecret
because no identity-based policy allows the secretsmanager:CreateSecret action
```

…on `JiraIntegrationWebhookSecre-…`.

**Root cause:** the custom least-privilege CFN execution-role policy (ADR-002) scopes `secretsmanager:CreateSecret` to per-integration ARN prefixes (`GitHubTokenSecret*`, `SlackIntegration*`, `LinearIntegration*`, `GitHubScreenshot*`, `backgroundagent-*`, `bgagent/*`), but the **Jira** integration shipped without its pattern. `cdk/src/constructs/jira-integration.ts` creates `new secretsmanager.Secret(this, 'WebhookSecret')` under construct id `JiraIntegration` → CloudFormation names it `JiraIntegrationWebhookSecre-…`, which matches no allow-listed prefix, so the scoped exec role can't create it and the stack rolls back.

This is invisible to anyone with an already-deployed stack (older code, predating the Jira integration) and only bites a fresh deploy of current `main` through the current scoped bootstrap.

## Changes

- Add `arn:aws:secretsmanager:*:*:secret:JiraIntegration*` to the `SecretsManager` statement in `cdk/src/bootstrap/policies/application.ts`.
- Regenerate bootstrap artifacts (`cdk/bootstrap/policies/application.json`, `cdk/bootstrap/bootstrap-template.yaml`) via `mise //cdk:bootstrap:generate`.
- Add a regression guard in `cdk/test/bootstrap/policies.test.ts` asserting the allow-list carries a secret pattern for **every** integration that creates a secret. The existing service-prefix check can't catch a missing resource ARN (it's still `secretsmanager:`), which is precisely how this reached `main`.

## Testing

- `mise //cdk:compile` — clean
- `mise //cdk:eslint` — clean
- `mise //cdk:test` (bootstrap suites) — 62 passing, including the new guard
- Verified the new pattern is present in source, `application.json`, and `bootstrap-template.yaml` (all in sync)

Fixes #402