### PR TITLE
fix(cdk): grant s3:PutBucketVersioning in bootstrap policy (#404)

### DIFF
--- a/cdk/bootstrap/bootstrap-template.yaml
+++ b/cdk/bootstrap/bootstrap-template.yaml
@@ -1224,6 +1224,8 @@ Resources:
               - s3:GetBucketPublicAccessBlock
               - s3:PutEncryptionConfiguration
               - s3:PutLifecycleConfiguration
+              - s3:PutBucketVersioning
+              - s3:GetBucketVersioning
               - s3:GetBucketLocation
               - s3:ListBucket
               - s3:PutBucketTagging

--- a/cdk/bootstrap/policies/observability.json
+++ b/cdk/bootstrap/policies/observability.json
@@ -90,6 +90,8 @@
         "s3:GetBucketPublicAccessBlock",
         "s3:PutEncryptionConfiguration",
         "s3:PutLifecycleConfiguration",
+        "s3:PutBucketVersioning",
+        "s3:GetBucketVersioning",
         "s3:GetBucketLocation",
         "s3:ListBucket",
         "s3:PutBucketTagging",

--- a/cdk/src/bootstrap/policies/observability.ts
+++ b/cdk/src/bootstrap/policies/observability.ts
@@ -127,6 +127,8 @@ export function observabilityPolicy(): iam.PolicyDocument {
           's3:GetBucketPublicAccessBlock',
           's3:PutEncryptionConfiguration',
           's3:PutLifecycleConfiguration',
+          's3:PutBucketVersioning',
+          's3:GetBucketVersioning',
           's3:GetBucketLocation',
           's3:ListBucket',
           's3:PutBucketTagging',

--- a/cdk/test/bootstrap/policies.test.ts
+++ b/cdk/test/bootstrap/policies.test.ts
@@ -215,6 +215,38 @@ describe('IaCRole-ABCA-Observability', () => {
       ]),
     );
   });
+
+  it('S3ApplicationBuckets grants the bucket-feature actions the stack buckets enable', () => {
+    // Regression guard for #404: the exec role must hold a CreateBucket-time
+    // action for every feature the application buckets turn on, or a fresh
+    // deploy rolls back with AccessDenied at that specific configure call.
+    // AttachmentsBucket sets `versioned: true`, so PutBucketVersioning (and
+    // GetBucketVersioning for the read/drift path) are required — they were
+    // missing, which is how this reached main. The service-prefix check above
+    // can't catch it (still `s3:`). If a bucket later enables notifications,
+    // CORS, etc., add the matching action here and to the policy together.
+    const resolvedDoc = stack.resolve(doc);
+    const statements = resolvedDoc.Statement as Array<{
+      Sid: string;
+      Action?: string | string[];
+    }>;
+    const s3Buckets = statements.find((s) => s.Sid === 'S3ApplicationBuckets');
+    expect(s3Buckets).toBeDefined();
+
+    const actions = Array.isArray(s3Buckets!.Action)
+      ? s3Buckets!.Action
+      : [s3Buckets!.Action];
+
+    for (const action of [
+      's3:CreateBucket',
+      's3:PutEncryptionConfiguration',
+      's3:PutLifecycleConfiguration',
+      's3:PutBucketVersioning',
+      's3:GetBucketVersioning',
+    ]) {
+      expect(actions).toContain(action);
+    }
+  });
 });
 
 describe('IaCRole-ABCA-Compute-AgentCore', () => {

--- a/docs/design/DEPLOYMENT_ROLES.md
+++ b/docs/design/DEPLOYMENT_ROLES.md
@@ -597,6 +597,8 @@ Bedrock Guardrails, CloudWatch Logs/Dashboards/Alarms, X-Ray, S3 (CDK assets), K
         "s3:GetBucketPublicAccessBlock",
         "s3:PutEncryptionConfiguration",
         "s3:PutLifecycleConfiguration",
+        "s3:PutBucketVersioning",
+        "s3:GetBucketVersioning",
         "s3:GetBucketLocation",
         "s3:ListBucket",
         "s3:PutBucketTagging",

--- a/docs/src/content/docs/architecture/Deployment-roles.md
+++ b/docs/src/content/docs/architecture/Deployment-roles.md
@@ -601,6 +601,8 @@ Bedrock Guardrails, CloudWatch Logs/Dashboards/Alarms, X-Ray, S3 (CDK assets), K
         "s3:GetBucketPublicAccessBlock",
         "s3:PutEncryptionConfiguration",
         "s3:PutLifecycleConfiguration",
+        "s3:PutBucketVersioning",
+        "s3:GetBucketVersioning",
         "s3:GetBucketLocation",
         "s3:ListBucket",
         "s3:PutBucketTagging",


### PR DESCRIPTION
## Summary

A fresh `mise //cdk:bootstrap` + `mise //cdk:deploy` of current `main` rolls back when CloudFormation creates the `AttachmentsBucket`:

```
cdk-hnb659fds-cfn-exec-role is not authorized to perform s3:PutBucketVersioning
```

**Root cause:** `AttachmentsBucket` (`cdk/src/constructs/attachments-bucket.ts`) sets `versioned: true`, so CloudFormation issues `s3:PutBucketVersioning` during creation. The `S3ApplicationBuckets` statement in `cdk/src/bootstrap/policies/observability.ts` grants `CreateBucket`, `PutEncryptionConfiguration`, `PutLifecycleConfiguration`, `PutBucketPublicAccessBlock` (+Get), `PutBucketTagging` (+Get), etc. — but **no `s3:PutBucketVersioning`** (nor `s3:GetBucketVersioning` for the read/drift path).

This is the same drift class as #402/#403: a stack feature whose CREATE-time action was never added to the scoped exec-role policy. It's invisible to an existing deployment (the action only fires when the versioned bucket is first created) and only surfaces on a from-scratch deploy through the current least-privilege bootstrap.

### Bucket audit (versioning is the only gap)

| Bucket | Versioned | Other features |
|---|---|---|
| AttachmentsBucket | **yes** | encryption, lifecycle, enforceSSL, BPA, tagging — all already covered |
| TraceArtifactsBucket | no | same |
| ScreenshotBucket | no | same + CloudFront (separate service) |

## Changes

- Add `s3:PutBucketVersioning` and `s3:GetBucketVersioning` to the `S3ApplicationBuckets` statement in `observability.ts` (matching the existing Put/Get pairing for PublicAccessBlock and Tagging).
- Regenerate bootstrap artifacts (`observability.json`, `bootstrap-template.yaml`).
- Update the `DEPLOYMENT_ROLES.md` golden source-of-truth (+ Starlight mirror) so the golden-baseline parity test passes.
- Add a regression guard in `policies.test.ts` asserting `S3ApplicationBuckets` carries an action for each bucket feature the stack enables (the service-prefix check can't catch a missing action — it's still `s3:`).

## Testing

- `mise //cdk:eslint` — clean
- `mise //cdk:test` — 121 suites / 2194 tests pass, incl. golden-baseline parity and the new guard
- Verified `PutBucketVersioning` present in source, `observability.json`, `bootstrap-template.yaml`, `DEPLOYMENT_ROLES.md`, and the Starlight mirror

## Related

Follows #403 (Jira secret pattern). Both are instances of bootstrap allow-list drift; the durable fix is a pre-deploy check that synthesizes the stack and diffs the CFN exec role's required actions against the bootstrap policy, surfacing all gaps before a deploy rather than one rollback at a time.

Fixes #404