### PR TITLE
fix(cdk): grant lambda Tag/UntagResource on event-source-mappings (#407)

### DIFF
--- a/cdk/bootstrap/bootstrap-template.yaml
+++ b/cdk/bootstrap/bootstrap-template.yaml
@@ -1019,6 +1019,8 @@ Resources:
               - lambda:DeleteEventSourceMapping
               - lambda:UpdateEventSourceMapping
               - lambda:GetEventSourceMapping
+              - lambda:TagResource
+              - lambda:UntagResource
             Effect: Allow
             Resource: '*'
             Sid: LambdaEventSourceMappings

--- a/cdk/bootstrap/policies/application.json
+++ b/cdk/bootstrap/policies/application.json
@@ -70,7 +70,9 @@
         "lambda:CreateEventSourceMapping",
         "lambda:DeleteEventSourceMapping",
         "lambda:UpdateEventSourceMapping",
-        "lambda:GetEventSourceMapping"
+        "lambda:GetEventSourceMapping",
+        "lambda:TagResource",
+        "lambda:UntagResource"
       ],
       "Effect": "Allow",
       "Resource": "*",

--- a/cdk/src/bootstrap/policies/application.ts
+++ b/cdk/src/bootstrap/policies/application.ts
@@ -106,6 +106,12 @@ export function applicationPolicy(): iam.PolicyDocument {
           'lambda:DeleteEventSourceMapping',
           'lambda:UpdateEventSourceMapping',
           'lambda:GetEventSourceMapping',
+          // CDK event-source constructs (e.g. DynamoDBEventSource) tag the
+          // created mapping, so the exec role needs Tag/UntagResource on
+          // event-source-mapping:* (the function:*/layer:*-scoped TagResource
+          // grant elsewhere in this policy does not cover mappings).
+          'lambda:TagResource',
+          'lambda:UntagResource',
         ],
         resources: ['*'],
       }),

--- a/cdk/test/bootstrap/policies.test.ts
+++ b/cdk/test/bootstrap/policies.test.ts
@@ -149,6 +149,22 @@ describe('IaCRole-ABCA-Application', () => {
     );
   });
 
+  it('LambdaEventSourceMappings grants tagging (CDK event-source constructs tag the mapping)', () => {
+    // Regression guard for #407: DynamoDBEventSource (and peers) tag the
+    // created event source mapping, so the exec role needs Tag/UntagResource
+    // on event-source-mapping:*. The TagResource granted elsewhere is scoped
+    // to function:*/layer:* and does not cover mappings, so a fresh deploy
+    // rolled back with AccessDenied on lambda:TagResource. Lock the contract.
+    const resolvedDoc = stack.resolve(doc);
+    const statements = resolvedDoc.Statement as Array<{ Sid: string; Action?: string | string[] }>;
+    const esm = statements.find((s) => s.Sid === 'LambdaEventSourceMappings');
+    expect(esm).toBeDefined();
+
+    const actions = Array.isArray(esm!.Action) ? esm!.Action : [esm!.Action];
+    expect(actions).toContain('lambda:TagResource');
+    expect(actions).toContain('lambda:UntagResource');
+  });
+
   it('SecretsManager statement allow-lists a secret pattern for every integration that creates a secret', () => {
     // Regression guard for #402: each integration construct that creates a
     // Secrets Manager secret (GitHub token, Slack, Linear, Jira, GitHub

--- a/docs/design/DEPLOYMENT_ROLES.md
+++ b/docs/design/DEPLOYMENT_ROLES.md
@@ -339,7 +339,9 @@ DynamoDB tables, Lambda functions, API Gateway, Cognito, WAFv2, EventBridge, SQS
         "lambda:CreateEventSourceMapping",
         "lambda:DeleteEventSourceMapping",
         "lambda:UpdateEventSourceMapping",
-        "lambda:GetEventSourceMapping"
+        "lambda:GetEventSourceMapping",
+        "lambda:TagResource",
+        "lambda:UntagResource"
       ],
       "Resource": "*"
     },

--- a/docs/src/content/docs/architecture/Deployment-roles.md
+++ b/docs/src/content/docs/architecture/Deployment-roles.md
@@ -343,7 +343,9 @@ DynamoDB tables, Lambda functions, API Gateway, Cognito, WAFv2, EventBridge, SQS
         "lambda:CreateEventSourceMapping",
         "lambda:DeleteEventSourceMapping",
         "lambda:UpdateEventSourceMapping",
-        "lambda:GetEventSourceMapping"
+        "lambda:GetEventSourceMapping",
+        "lambda:TagResource",
+        "lambda:UntagResource"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
## Summary

A fresh `mise //cdk:bootstrap` + `mise //cdk:deploy` of current `main` rolls back deep into the stack (~303 resources processed) when CloudFormation creates a Lambda event source mapping:

```
cdk-hnb659fds-cfn-exec-role is not authorized to perform lambda:TagResource
on arn:aws:lambda:...:event-source-mapping:*
```

**Root cause:** CDK's `DynamoDBEventSource` (and peers) tag the created event source mapping, so the exec role needs `lambda:TagResource` on `event-source-mapping:*`. The `LambdaEventSourceMappings` statement in `cdk/src/bootstrap/policies/application.ts` grants Create/Delete/Update/Get on `*` but **not** the tagging actions, and the `lambda:TagResource` granted elsewhere in the policy is scoped to `function:*`/`layer:*`, which does not cover mappings.

Same drift class as #402/#403 (Jira secret) and #404/#405 (S3 versioning): a deploy-time action never added to the scoped exec-role policy — invisible to existing stacks, fatal to a from-scratch deploy.

## Changes

- Add `lambda:TagResource` and `lambda:UntagResource` to the `LambdaEventSourceMappings` statement (resources already `*`).
- Regenerate bootstrap artifacts (`application.json`, `bootstrap-template.yaml`).
- Update `DEPLOYMENT_ROLES.md` golden source-of-truth (+ Starlight mirror) for golden-baseline parity.
- Add a regression guard in `policies.test.ts`.

## Testing

- `mise //cdk:eslint` — clean
- `mise //cdk:test` — 121 suites / 2195 tests pass, incl. golden-baseline parity and the new guard
- Verified `lambda:TagResource` present in source, `application.json`, `bootstrap-template.yaml`, `DEPLOYMENT_ROLES.md`, and the Starlight mirror

## Related

Third instance of bootstrap allow-list drift (after #403, #405). The CI gap that lets all three through — the coarse `RESOURCE_ACTION_MAP` (create-verb only, no tag/property/ARN awareness) — is tracked in #406, where this serves as a test case.

Fixes #407