### PR TITLE
fix(cdk): grant lambda Put/DeleteProvisionedConcurrencyConfig (#409)

### DIFF
--- a/cdk/bootstrap/bootstrap-template.yaml
+++ b/cdk/bootstrap/bootstrap-template.yaml
@@ -1002,6 +1002,8 @@ Resources:
               - lambda:GetFunctionCodeSigningConfig
               - lambda:GetFunctionRecursionConfig
               - lambda:GetProvisionedConcurrencyConfig
+              - lambda:PutProvisionedConcurrencyConfig
+              - lambda:DeleteProvisionedConcurrencyConfig
               - lambda:GetRuntimeManagementConfig
               - lambda:ListVersionsByFunction
               - lambda:InvokeFunction

--- a/cdk/bootstrap/policies/application.json
+++ b/cdk/bootstrap/policies/application.json
@@ -50,6 +50,8 @@
         "lambda:GetFunctionCodeSigningConfig",
         "lambda:GetFunctionRecursionConfig",
         "lambda:GetProvisionedConcurrencyConfig",
+        "lambda:PutProvisionedConcurrencyConfig",
+        "lambda:DeleteProvisionedConcurrencyConfig",
         "lambda:GetRuntimeManagementConfig",
         "lambda:ListVersionsByFunction",
         "lambda:InvokeFunction",

--- a/cdk/src/bootstrap/policies/application.ts
+++ b/cdk/src/bootstrap/policies/application.ts
@@ -84,6 +84,8 @@ export function applicationPolicy(): iam.PolicyDocument {
           'lambda:GetFunctionCodeSigningConfig',
           'lambda:GetFunctionRecursionConfig',
           'lambda:GetProvisionedConcurrencyConfig',
+          'lambda:PutProvisionedConcurrencyConfig',
+          'lambda:DeleteProvisionedConcurrencyConfig',
           'lambda:GetRuntimeManagementConfig',
           'lambda:ListVersionsByFunction',
           'lambda:InvokeFunction',

--- a/cdk/test/bootstrap/policies.test.ts
+++ b/cdk/test/bootstrap/policies.test.ts
@@ -149,6 +149,20 @@ describe('IaCRole-ABCA-Application', () => {
     );
   });
 
+  it('grants Put/Delete provisioned-concurrency, not just Get (#409)', () => {
+    // The Slack-events function pins provisioned concurrency on its `live`
+    // alias, so the exec role needs Put (create/update) and Delete (removal),
+    // not only the Get verb. Get-without-Put rolled the deploy back with
+    // AccessDenied on lambda:PutProvisionedConcurrencyConfig.
+    const resolvedDoc = stack.resolve(doc);
+    const statements = resolvedDoc.Statement as Array<{ Action: string | string[] }>;
+    const allActions = statements.flatMap((s) =>
+      Array.isArray(s.Action) ? s.Action : [s.Action],
+    );
+    expect(allActions).toContain('lambda:PutProvisionedConcurrencyConfig');
+    expect(allActions).toContain('lambda:DeleteProvisionedConcurrencyConfig');
+  });
+
   it('SecretsManager statement allow-lists a secret pattern for every integration that creates a secret', () => {
     // Regression guard for #402: each integration construct that creates a
     // Secrets Manager secret (GitHub token, Slack, Linear, Jira, GitHub

--- a/docs/design/DEPLOYMENT_ROLES.md
+++ b/docs/design/DEPLOYMENT_ROLES.md
@@ -319,6 +319,8 @@ DynamoDB tables, Lambda functions, API Gateway, Cognito, WAFv2, EventBridge, SQS
         "lambda:GetFunctionCodeSigningConfig",
         "lambda:GetFunctionRecursionConfig",
         "lambda:GetProvisionedConcurrencyConfig",
+        "lambda:PutProvisionedConcurrencyConfig",
+        "lambda:DeleteProvisionedConcurrencyConfig",
         "lambda:GetRuntimeManagementConfig",
         "lambda:ListVersionsByFunction",
         "lambda:InvokeFunction",

--- a/docs/src/content/docs/architecture/Deployment-roles.md
+++ b/docs/src/content/docs/architecture/Deployment-roles.md
@@ -323,6 +323,8 @@ DynamoDB tables, Lambda functions, API Gateway, Cognito, WAFv2, EventBridge, SQS
         "lambda:GetFunctionCodeSigningConfig",
         "lambda:GetFunctionRecursionConfig",
         "lambda:GetProvisionedConcurrencyConfig",
+        "lambda:PutProvisionedConcurrencyConfig",
+        "lambda:DeleteProvisionedConcurrencyConfig",
         "lambda:GetRuntimeManagementConfig",
         "lambda:ListVersionsByFunction",
         "lambda:InvokeFunction",


### PR DESCRIPTION
## Summary

A fresh `mise //cdk:bootstrap` + `mise //cdk:deploy` of current `main` rolls back when CloudFormation configures provisioned concurrency on the Slack-events function's `live` alias:

```
cdk-hnb659fds-cfn-exec-role is not authorized to perform lambda:PutProvisionedConcurrencyConfig
```

**Root cause:** `SlackIntegrationSlackEventsFnAliaslive` is an `AWS::Lambda::Alias` carrying a `ProvisionedConcurrencyConfig` property (confirmed via synth). Configuring it needs `lambda:PutProvisionedConcurrencyConfig` (and `Delete` on removal). The `Lambda` statement in `cdk/src/bootstrap/policies/application.ts` granted only `lambda:GetProvisionedConcurrencyConfig`. The resource ARN (`function:backgroundagent-dev-*`) is already covered — only the actions were missing.

Same drift class as #402/#403, #404/#405, #407/#408.

## Changes

- Add `lambda:PutProvisionedConcurrencyConfig` and `lambda:DeleteProvisionedConcurrencyConfig` next to the existing `Get` verb in the `Lambda` statement.
- Regenerate bootstrap artifacts (`application.json`, `bootstrap-template.yaml`).
- Update `DEPLOYMENT_ROLES.md` golden (+ Starlight mirror) for golden-baseline parity.
- Add a regression guard in `policies.test.ts`.

## Testing

- `mise //cdk:eslint` — clean
- `mise //cdk:test` — 2195 tests pass, incl. golden-baseline parity and the new guard
- Verified the actions are present in source, `application.json`, `bootstrap-template.yaml`, `DEPLOYMENT_ROLES.md`, and the mirror

Fixes #409