### PR TITLE
fix: two bugs that prevent ECS Fargate from working

### DIFF
--- a/cdk/bootstrap/bootstrap-template.yaml
+++ b/cdk/bootstrap/bootstrap-template.yaml
@@ -821,6 +821,7 @@ Resources:
               - iam:DeleteRole
               - iam:GetRole
               - iam:UpdateRole
+              - iam:UpdateAssumeRolePolicy
               - iam:TagRole
               - iam:UntagRole
               - iam:ListRoleTags

--- a/cdk/bootstrap/policies/infrastructure.json
+++ b/cdk/bootstrap/policies/infrastructure.json
@@ -32,6 +32,7 @@
         "iam:DeleteRole",
         "iam:GetRole",
         "iam:UpdateRole",
+        "iam:UpdateAssumeRolePolicy",
         "iam:TagRole",
         "iam:UntagRole",
         "iam:ListRoleTags",

--- a/cdk/src/bootstrap/policies/infrastructure.ts
+++ b/cdk/src/bootstrap/policies/infrastructure.ts
@@ -66,6 +66,7 @@ export function infrastructurePolicy(): iam.PolicyDocument {
           'iam:DeleteRole',
           'iam:GetRole',
           'iam:UpdateRole',
+          'iam:UpdateAssumeRolePolicy',
           'iam:TagRole',
           'iam:UntagRole',
           'iam:ListRoleTags',

--- a/cdk/src/handlers/shared/strategies/ecs-strategy.ts
+++ b/cdk/src/handlers/shared/strategies/ecs-strategy.ts
@@ -90,7 +90,7 @@ export class EcsComputeStrategy implements ComputeStrategy {
     const bootCommand = [
       'python', '-c',
       'import json, os, sys; '
-      + 'sys.path.insert(0, "/app"); '
+      + 'sys.path.insert(0, "/app/src"); '
       + 'from entrypoint import run_task; '
       + 'p = json.loads(os.environ["AGENT_PAYLOAD"]); '
       + 'r = run_task('

--- a/docs/design/DEPLOYMENT_ROLES.md
+++ b/docs/design/DEPLOYMENT_ROLES.md
@@ -117,6 +117,7 @@ CloudFormation stack operations, IAM roles/policies, VPC networking, and Route 5
         "iam:DeleteRole",
         "iam:GetRole",
         "iam:UpdateRole",
+        "iam:UpdateAssumeRolePolicy",
         "iam:TagRole",
         "iam:UntagRole",
         "iam:ListRoleTags",

--- a/docs/src/content/docs/architecture/Deployment-roles.md
+++ b/docs/src/content/docs/architecture/Deployment-roles.md
@@ -121,6 +121,7 @@ CloudFormation stack operations, IAM roles/policies, VPC networking, and Route 5
         "iam:DeleteRole",
         "iam:GetRole",
         "iam:UpdateRole",
+        "iam:UpdateAssumeRolePolicy",
         "iam:TagRole",
         "iam:UntagRole",
         "iam:ListRoleTags",


### PR DESCRIPTION
Tried turning on the EcsAgentCluster construct (the one shipped commented out in `cdk/src/stacks/agent.ts`) and hit two things back to back that blocked it.

First: the bootstrap policy at `cdk/src/bootstrap/policies/infrastructure.ts` is missing `iam:UpdateAssumeRolePolicy`. When ECS is enabled, `AgentSessionRole.admitComputeRole(ecsTaskRole)` rewrites the SessionRole trust — fails at deploy time with `User: cdk-...-cfn-exec-role is not authorized to perform: iam:UpdateAssumeRolePolicy`.

Second: `cdk/src/handlers/shared/strategies/ecs-strategy.ts:93` has the boot command do `sys.path.insert(0, "/app")` and `from entrypoint import run_task`, but `agent/Dockerfile` copies the agent code to `/app/src/`. Container exits 1 immediately with `ModuleNotFoundError: No module named 'entrypoint'`. Easy to miss — the orchestrator just surfaces "Essential container exited"; you have to dig into the ECS task's CloudWatch stream to see the actual error.

Verified: uncommented `EcsAgentCluster` locally, set a repo to `compute_type=ecs`, submitted a smoke task on a Rust repo. `cargo check` ran clean inside the ECS container (exit 0, ~78s wall, $0.09).