### PR TITLE
fix: baseline gitleaks false-positive test fixture (#530)

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -5,3 +5,10 @@
 0dca2171f244f693ac7c649ecf376d1ce6af2b38:docs/backlog/EARLY_PROGRESS_MILESTONES.md:aws-account-id:5
 0dca2171f244f693ac7c649ecf376d1ce6af2b38:docs/backlog/CLI_COGNITO_NEW_PASSWORD_CHALLENGE.md:aws-account-id:5
 0dca2171f244f693ac7c649ecf376d1ce6af2b38:docs/diagrams/phase3-cedar-hitl.drawio:aws-account-id:28
+
+# False positive: generic-api-key on a test idempotency-key fixture
+# ('orch_abc_SUB-1', not a real credential) in a file that no longer exists at
+# HEAD — it was removed when the #76 bounded-parallel perf commit was reverted
+# (e8bee5e). The finding lives only in history at f98f47a, so it can't be
+# scrubbed without rewriting shared `main`; fingerprint it instead. See #530.
+f98f47abc6f7820d7e5ce0375cf22551cb664b37:cdk/test/handlers/shared/orchestration-release.test.ts:generic-api-key:125


### PR DESCRIPTION
## What

Baseline a gitleaks false-positive fingerprint in `.gitleaksignore` so the security suite's secret scan passes.

Fixes #530. (Also resolves #401 — same finding, older duplicate.)

## Root cause

gitleaks `generic-api-key` fired on a **test idempotency-key fixture** (`orch_abc_SUB-1`) at `cdk/test/handlers/shared/orchestration-release.test.ts:125`. It is not a real credential. The file no longer exists at HEAD — it was removed when #76's bounded-parallel perf commit was reverted (`e8bee5e`). The finding survives only in git history at commit `f98f47a`, so it cannot be scrubbed without rewriting shared `main`.

## Fix

Add the finding's fingerprint to `.gitleaksignore`, matching the existing historical-baseline pattern already used for the #313 aws-account-id findings, with an explanatory comment. One file, +7 lines.

## Verification

`mise run security:secrets` (the exact command the required `Secrets, deps, and workflow scan` check runs) goes from `leaks found: 1` → **`no leaks found`** (exit 0), on the commit #530 references.

## Note — this PR does not make the *full* security suite green

`mise run security` is fail-fast; today it dies at gitleaks (this fix) before reaching semgrep. Once this merges, the scheduled full-suite run will surface a **pre-existing, unrelated** semgrep finding (`uv-missing-dependency-cooldown` on `agent/pyproject.toml`) that was masked behind the gitleaks failure. That is **not a regression from this PR** — it is tracked separately in **#532** and will be fixed on its own branch. The required PR merge check (`Secrets, deps, and workflow scan`) does not run semgrep, so this PR is independently mergeable.

Co-Authored-By: Claude <noreply@anthropic.com>
