### PR TITLE
fix(security): suppress orch fixture via stopword, not SHA fingerprint (#537)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -19,6 +19,15 @@ stopwords = ["wat-opaque-123"]
 description = "Test fixture signing secret in Slack verification unit test (not a real credential)."
 stopwords = ["test-signing-secret-abc123"]
 
+[[allowlists]]
+# Test idempotency-key fixture in orchestration-release.test.ts (not a real
+# credential). Suppressed by stopword rather than a .gitleaksignore commit-SHA
+# fingerprint: the finding lives in history and SHA fingerprints break whenever
+# history is rewritten (rebases / dep-bump merges), which is exactly how #530's
+# baseline regressed. A stopword is SHA-independent. See #537 (regression of #530).
+description = "Test idempotency-key fixture 'orch_abc_SUB-1' (not a real credential)."
+stopwords = ["orch_abc_SUB-1"]
+
 # Catch bare 12-digit AWS account IDs. The default ruleset does not flag these,
 # which is how a real account ID reached a committed comment in the #236 integ
 # work. RE2 (Go) has no lookarounds, so the non-digit neighbours are captured in

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -6,9 +6,7 @@
 0dca2171f244f693ac7c649ecf376d1ce6af2b38:docs/backlog/CLI_COGNITO_NEW_PASSWORD_CHALLENGE.md:aws-account-id:5
 0dca2171f244f693ac7c649ecf376d1ce6af2b38:docs/diagrams/phase3-cedar-hitl.drawio:aws-account-id:28
 
-# False positive: generic-api-key on a test idempotency-key fixture
-# ('orch_abc_SUB-1', not a real credential) in a file that no longer exists at
-# HEAD — it was removed when the #76 bounded-parallel perf commit was reverted
-# (e8bee5e). The finding lives only in history at f98f47a, so it can't be
-# scrubbed without rewriting shared `main`; fingerprint it instead. See #530.
-f98f47abc6f7820d7e5ce0375cf22551cb664b37:cdk/test/handlers/shared/orchestration-release.test.ts:generic-api-key:125
+# NOTE: the orch_abc_SUB-1 test-fixture false positive (formerly baselined here
+# by commit-SHA fingerprint, #530) is now suppressed SHA-independently via a
+# stopword allowlist in .gitleaks.toml — a commit-SHA fingerprint here broke when
+# history was rewritten. See #537.


### PR DESCRIPTION
## What

Fix gitleaks failing on `main`: replace the SHA-keyed `.gitleaksignore` fingerprint for the `orch_abc_SUB-1` test fixture with a SHA-independent stopword allowlist in `.gitleaks.toml`.

Fixes #537.

## Why

#530 baselined a gitleaks false positive (test idempotency-key fixture `orch_abc_SUB-1` in `cdk/test/handlers/shared/orchestration-release.test.ts:125`) using a **commit-SHA fingerprint**. A later history rewrite (dep-bump merges, #526 et al.) changed that commit's SHA (`f98f47a` → `73bfe08`), so the fingerprint stopped matching and the finding resurfaced — turning `security:secrets` red on `main` for everyone and blocking any PR (the required `Secrets, deps, and workflow scan` check runs gitleaks). It also blocks #532.

SHA-keyed fingerprints are inherently fragile to history rewrites. A stopword allowlist keys on the secret *value*, so it survives rebases/merges.

## Change

- `.gitleaks.toml` — add a stopword allowlist for `orch_abc_SUB-1`, matching the existing fixture pattern (`wat-opaque-123`, `test-signing-secret-abc123`), with a comment explaining the SHA-fragility rationale.
- `.gitleaksignore` — remove the stale `f98f47a` fingerprint; leave a breadcrumb pointing to the new location.

## Verification

- `mise run security:secrets` → **`no leaks found`** (exit 0).
- Full gitleaks scan → **0 findings**; the three #313 aws-account-id fingerprints remain intact and suppressed.
- Over-suppression check: `orch_abc_SUB-1` is a 14-char fixed literal, present in the live tree only in the config references (the test file was deleted) — it cannot mask a broader/real secret.
- Scope: `.gitleaks.toml` + `.gitleaksignore` only.

## Note

Consider auditing the #313 aws-account-id fingerprints for the same SHA-fragility in a follow-up (out of scope here).

Co-Authored-By: Claude <noreply@anthropic.com>
