### PR TITLE
fix(jira): pin coding/new-task-v1 workflow_ref in webhook processor

### DIFF
--- a/cdk/src/handlers/jira-webhook-processor.ts
+++ b/cdk/src/handlers/jira-webhook-processor.ts
@@ -367,6 +367,10 @@ export async function handler(event: ProcessorEvent): Promise<void> {
     {
       repo,
       task_description: taskDescription,
+      // Explicit coding workflow: a label-triggered Jira task always targets a
+      // mapped repo, so it must not fall through the resolution ladder to the
+      // repo-less default/agent-v1 (which never commits or opens a PR). #546
+      workflow_ref: 'coding/new-task-v1',
       ...(attachments.length > 0 && { attachments }),
     },
     {

--- a/cdk/test/handlers/jira-webhook-processor.test.ts
+++ b/cdk/test/handlers/jira-webhook-processor.test.ts
@@ -297,6 +297,9 @@ describe('jira-webhook-processor handler', () => {
     expect(reqBody.repo).toBe('org/repo');
     expect(reqBody.task_description).toContain('ENG-42: Fix the login bug');
     expect(reqBody.task_description).toContain('Users cannot log in.');
+    // Must pin the coding workflow — an absent workflow_ref falls through the
+    // resolution ladder to default/agent-v1, which never opens a PR (#546).
+    expect(reqBody.workflow_ref).toBe('coding/new-task-v1');
     expect(ctx.userId).toBe('cognito-user-1');
     expect(ctx.channelSource).toBe('jira');
     expect(ctx.channelMetadata).toMatchObject({

--- a/docs/guides/JIRA_SETUP_GUIDE.md
+++ b/docs/guides/JIRA_SETUP_GUIDE.md
@@ -13,7 +13,7 @@ Set up the ABCA Jira Cloud integration so that adding a label to a Jira issue tr
 
 ## How it works
 
-A Jira-site admin creates an Atlassian OAuth 2.0 (3LO) app and authorizes it on the site. The OAuth token bundle is stored in a per-tenant Secrets Manager secret (`bgagent-jira-oauth-<cloudId>`). When a user adds the trigger label to a Jira issue, Jira fires a webhook to ABCA; the receiver verifies the `X-Hub-Signature` HMAC, dedupes, and async-invokes the processor, which resolves the tenant, looks up the project→repo mapping, and creates a task. The agent clones the repo, opens a PR, and comments on the Jira issue via the Jira REST v3 API (using the same stored OAuth token).
+A Jira-site admin creates an Atlassian OAuth 2.0 (3LO) app and authorizes it on the site. The OAuth token bundle is stored in a per-tenant Secrets Manager secret (`bgagent-jira-oauth-<cloudId>`). When a user adds the trigger label to a Jira issue, Jira fires a webhook to ABCA; the receiver verifies the `X-Hub-Signature` HMAC, dedupes, and async-invokes the processor, which resolves the tenant, looks up the project→repo mapping, and creates a task. Jira-triggered tasks always run the `coding/new-task-v1` workflow (the processor pins `workflow_ref` explicitly, since a label-triggered task always targets a mapped repo). The agent clones the repo, opens a PR, and comments on the Jira issue via the Jira REST v3 API (using the same stored OAuth token).
 
 **Tenant key.** Everything is indexed on `cloudId` — the Atlassian tenant UUID, *not* the site domain or name. Webhook payloads and the OAuth flow both surface `cloudId`; it is the join key across the project-mapping, user-mapping, and workspace-registry tables.
 

--- a/docs/src/content/docs/using/Jira-setup-guide.md
+++ b/docs/src/content/docs/using/Jira-setup-guide.md
@@ -17,7 +17,7 @@ Set up the ABCA Jira Cloud integration so that adding a label to a Jira issue tr
 
 ## How it works
 
-A Jira-site admin creates an Atlassian OAuth 2.0 (3LO) app and authorizes it on the site. The OAuth token bundle is stored in a per-tenant Secrets Manager secret (`bgagent-jira-oauth-<cloudId>`). When a user adds the trigger label to a Jira issue, Jira fires a webhook to ABCA; the receiver verifies the `X-Hub-Signature` HMAC, dedupes, and async-invokes the processor, which resolves the tenant, looks up the project→repo mapping, and creates a task. The agent clones the repo, opens a PR, and comments on the Jira issue via the Jira REST v3 API (using the same stored OAuth token).
+A Jira-site admin creates an Atlassian OAuth 2.0 (3LO) app and authorizes it on the site. The OAuth token bundle is stored in a per-tenant Secrets Manager secret (`bgagent-jira-oauth-<cloudId>`). When a user adds the trigger label to a Jira issue, Jira fires a webhook to ABCA; the receiver verifies the `X-Hub-Signature` HMAC, dedupes, and async-invokes the processor, which resolves the tenant, looks up the project→repo mapping, and creates a task. Jira-triggered tasks always run the `coding/new-task-v1` workflow (the processor pins `workflow_ref` explicitly, since a label-triggered task always targets a mapped repo). The agent clones the repo, opens a PR, and comments on the Jira issue via the Jira REST v3 API (using the same stored OAuth token).
 
 **Tenant key.** Everything is indexed on `cloudId` — the Atlassian tenant UUID, *not* the site domain or name. Webhook payloads and the OAuth flow both surface `cloudId`; it is the join key across the project-mapping, user-mapping, and workspace-registry tables.
 


### PR DESCRIPTION
## Stack position

PR 1 for #546 — Prior: none — This PR: pin the Jira coding workflow — Next: TBD (subsequent Jira channel features will stack on this branch).

## What

One-line fix + test + doc: the Jira webhook processor now submits `workflow_ref: 'coding/new-task-v1'` to `createTaskCore` instead of falling through the resolution ladder to `default/agent-v1`.

## Why

Fixes #546. A label-triggered Jira task carried no `workflow_ref`, so it resolved to the platform default `default/agent-v1` — an artifact-delivery workflow whose prompt explicitly forbids creating branches or PRs. Every Jira task therefore ended with **"✅ ABCA finished this task. No pull request was opened."** — contradicting `JIRA_SETUP_GUIDE.md` ("The agent clones the repo, opens a PR…"). Reproduced live twice (task IDs in the issue).

`coding/new-task-v1` is the correct target: `requiresRepo: true` (the processor always submits a mapped repo) and `requiredInputs: oneOf [issue_number, task_description]` (satisfied by the built description).

## Changes

- `cdk/src/handlers/jira-webhook-processor.ts` — pin `workflow_ref: 'coding/new-task-v1'` at the `createTaskCore` submission site
- `cdk/test/handlers/jira-webhook-processor.test.ts` — assert the pinned ref in the happy-path submission test
- `docs/guides/JIRA_SETUP_GUIDE.md` (+ generated Starlight mirror via `mise //docs:sync`) — document which workflow Jira tasks run

## Scope

Jira integration only

## Verification

- `mise run build` green (agent quality + cdk + cli + docs)
- `npx jest test/handlers/jira-webhook-processor.test.ts` — 41/41 pass
- E2E verification on a live stack (label flip → task runs `coding/new-task-v1` → PR opened → Jira comment carries PR link) to follow in an issue comment.