### PR TITLE
fix(bootstrap): grant missing Update* actions for DNS-firewall association + log delivery

### DIFF
--- a/cdk/bootstrap/bootstrap-template.yaml
+++ b/cdk/bootstrap/bootstrap-template.yaml
@@ -930,6 +930,7 @@ Resources:
               - route53resolver:UpdateFirewallDomains
               - route53resolver:AssociateFirewallRuleGroup
               - route53resolver:DisassociateFirewallRuleGroup
+              - route53resolver:UpdateFirewallRuleGroupAssociation
               - route53resolver:GetFirewallRuleGroupAssociation
               - route53resolver:ListFirewallRuleGroupAssociations
               - route53resolver:UpdateFirewallConfig

--- a/cdk/bootstrap/bootstrap-template.yaml
+++ b/cdk/bootstrap/bootstrap-template.yaml
@@ -1192,6 +1192,7 @@ Resources:
               - cloudwatch:TagResource
               - cloudwatch:UntagResource
               - logs:CreateDelivery
+              - logs:UpdateDeliveryConfiguration
               - logs:DescribeDeliveries
               - logs:GetDelivery
               - logs:GetDeliveryDestination

--- a/cdk/bootstrap/policies/infrastructure.json
+++ b/cdk/bootstrap/policies/infrastructure.json
@@ -153,6 +153,7 @@
         "route53resolver:UpdateFirewallDomains",
         "route53resolver:AssociateFirewallRuleGroup",
         "route53resolver:DisassociateFirewallRuleGroup",
+        "route53resolver:UpdateFirewallRuleGroupAssociation",
         "route53resolver:GetFirewallRuleGroupAssociation",
         "route53resolver:ListFirewallRuleGroupAssociations",
         "route53resolver:UpdateFirewallConfig",

--- a/cdk/bootstrap/policies/observability.json
+++ b/cdk/bootstrap/policies/observability.json
@@ -44,6 +44,7 @@
         "cloudwatch:TagResource",
         "cloudwatch:UntagResource",
         "logs:CreateDelivery",
+        "logs:UpdateDeliveryConfiguration",
         "logs:DescribeDeliveries",
         "logs:GetDelivery",
         "logs:GetDeliveryDestination",

--- a/cdk/src/bootstrap/policies/infrastructure.ts
+++ b/cdk/src/bootstrap/policies/infrastructure.ts
@@ -190,6 +190,7 @@ export function infrastructurePolicy(): iam.PolicyDocument {
           'route53resolver:UpdateFirewallDomains',
           'route53resolver:AssociateFirewallRuleGroup',
           'route53resolver:DisassociateFirewallRuleGroup',
+          'route53resolver:UpdateFirewallRuleGroupAssociation',
           'route53resolver:GetFirewallRuleGroupAssociation',
           'route53resolver:ListFirewallRuleGroupAssociations',
           'route53resolver:UpdateFirewallConfig',

--- a/cdk/src/bootstrap/policies/observability.ts
+++ b/cdk/src/bootstrap/policies/observability.ts
@@ -79,6 +79,7 @@ export function observabilityPolicy(): iam.PolicyDocument {
           'cloudwatch:TagResource',
           'cloudwatch:UntagResource',
           'logs:CreateDelivery',
+          'logs:UpdateDeliveryConfiguration',
           'logs:DescribeDeliveries',
           'logs:GetDelivery',
           'logs:GetDeliveryDestination',

--- a/docs/design/DEPLOYMENT_ROLES.md
+++ b/docs/design/DEPLOYMENT_ROLES.md
@@ -238,6 +238,7 @@ CloudFormation stack operations, IAM roles/policies, VPC networking, and Route 5
         "route53resolver:UpdateFirewallDomains",
         "route53resolver:AssociateFirewallRuleGroup",
         "route53resolver:DisassociateFirewallRuleGroup",
+        "route53resolver:UpdateFirewallRuleGroupAssociation",
         "route53resolver:GetFirewallRuleGroupAssociation",
         "route53resolver:ListFirewallRuleGroupAssociations",
         "route53resolver:UpdateFirewallConfig",

--- a/docs/design/DEPLOYMENT_ROLES.md
+++ b/docs/design/DEPLOYMENT_ROLES.md
@@ -558,6 +558,7 @@ Bedrock Guardrails, CloudWatch Logs/Dashboards/Alarms, X-Ray, S3 (CDK assets), K
         "cloudwatch:TagResource",
         "cloudwatch:UntagResource",
         "logs:CreateDelivery",
+        "logs:UpdateDeliveryConfiguration",
         "logs:DescribeDeliveries",
         "logs:GetDelivery",
         "logs:GetDeliveryDestination",

--- a/docs/src/content/docs/architecture/Deployment-roles.md
+++ b/docs/src/content/docs/architecture/Deployment-roles.md
@@ -562,6 +562,7 @@ Bedrock Guardrails, CloudWatch Logs/Dashboards/Alarms, X-Ray, S3 (CDK assets), K
         "cloudwatch:TagResource",
         "cloudwatch:UntagResource",
         "logs:CreateDelivery",
+        "logs:UpdateDeliveryConfiguration",
         "logs:DescribeDeliveries",
         "logs:GetDelivery",
         "logs:GetDeliveryDestination",

--- a/docs/src/content/docs/architecture/Deployment-roles.md
+++ b/docs/src/content/docs/architecture/Deployment-roles.md
@@ -242,6 +242,7 @@ CloudFormation stack operations, IAM roles/policies, VPC networking, and Route 5
         "route53resolver:UpdateFirewallDomains",
         "route53resolver:AssociateFirewallRuleGroup",
         "route53resolver:DisassociateFirewallRuleGroup",
+        "route53resolver:UpdateFirewallRuleGroupAssociation",
         "route53resolver:GetFirewallRuleGroupAssociation",
         "route53resolver:ListFirewallRuleGroupAssociations",
         "route53resolver:UpdateFirewallConfig",


### PR DESCRIPTION
## Summary

Two least-privilege bootstrap-policy gaps, both **live-caught deploying to a dev stack** and both the same class as the earlier bootstrap-drift fixes (#402/#404/#407/#409): the CloudFormation execution role is granted a resource's `Create*` action but not its `Update*` — so a **fresh create succeeds and only an in-place update fails** with `AccessDenied`, which is why they go unnoticed until an existing stack is updated.

### 1. `route53resolver:UpdateFirewallRuleGroupAssociation`
The `Route53ResolverDNSFirewall` statement grants `Associate`/`Disassociate`/`Get`/`List` on the firewall rule-group association but not `Update`. When CloudFormation does an in-place update of the existing `AWS::Route53Resolver::FirewallRuleGroupAssociation` (e.g. coming out of a rollback, or any change that rewrites the association), it hit `AccessDenied` and rolled back.

### 2. `logs:UpdateDeliveryConfiguration`
The observability statement grants `CreateDelivery` + the `LogDelivery` family + `Put/Get/Delete DeliverySource/Destination`, but not `UpdateDeliveryConfiguration`. An in-place update of `RuntimeApplicationLogsDelivery` (`AWS::Logs::Delivery`) failed on this action, which failed **both the update and its rollback** → the stack landed in `UPDATE_ROLLBACK_FAILED`. Adding the action + re-bootstrapping let `continue-update-rollback` complete cleanly and the redeploy succeed (verified live).

## What changed

- `cdk/src/bootstrap/policies/infrastructure.ts` — add `route53resolver:UpdateFirewallRuleGroupAssociation`.
- `cdk/src/bootstrap/policies/observability.ts` — add `logs:UpdateDeliveryConfiguration`.
- Regenerated artifacts (`cdk/bootstrap/policies/*.json`, `bootstrap-template.yaml`) via `mise //cdk:bootstrap:generate`, and updated the `DEPLOYMENT_ROLES.md` golden + its Starlight mirror to match.

## Testing

- Full `mise //cdk:test` — **124 suites / 2261 tests pass**, including the golden-baseline and docs-mirror drift gates (these only fail on the full run, not subsets).
- Live-verified: after adding both actions + re-bootstrapping, a previously-`UPDATE_ROLLBACK_FAILED` dev stack recovered via `continue-update-rollback` and a subsequent deploy reached `UPDATE_COMPLETE`.

## Notes for reviewers

- Both actions are scoped exactly like their existing `Create`/`Associate` siblings in the same statements — no new wildcards, IAM5 nag posture unchanged.
- Surfaced while deploying the ECS compute substrate, but **not ECS-specific**: these are latent gaps in the base bootstrap policy that any in-place update of the DNS-firewall association / log-delivery resource would hit. Independent of the ECS work.
