### PR TITLE
test(fix): stop context-hydration flake — delete ambient MEMORY_ID in beforeEach (#115)

### DIFF
--- a/cdk/test/handlers/shared/context-hydration.test.ts
+++ b/cdk/test/handlers/shared/context-hydration.test.ts
@@ -75,6 +75,15 @@ global.fetch = mockFetch as unknown as typeof fetch;
 beforeEach(() => {
   jest.clearAllMocks();
   clearTokenCache();
+  // hydrateContext falls back to process.env.MEMORY_ID when no memoryId option
+  // is passed (context-hydration.ts:990). If MEMORY_ID leaks into the jest
+  // process env (set by another test file, or the deploy env when the suite
+  // runs in-container), the "memoryId not provided" tests would spuriously call
+  // loadMemoryContext and fail — an order/environment-dependent flake that
+  // forced the fork's build-gate to be bypassed with `git push --no-verify`.
+  // Pin a clean "no ambient memory" baseline; tests that want memory pass the
+  // memoryId option explicitly.
+  delete process.env.MEMORY_ID;
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`context-hydration.test.ts` had an order/environment-dependent flake. `hydrateContext` falls back to `process.env.MEMORY_ID` when no `memoryId` option is passed. The "excludes memory_context when memoryId is not provided" tests assert `loadMemoryContext` is **not** called — but if `MEMORY_ID` leaked into the jest process env (set by another test file, or present in the deploy env when the suite runs in-container), the source picked it up and **did** call `loadMemoryContext`, failing the assertion.

Green locally (no `MEMORY_ID`), red on the fork's in-container build. Consequence: the flake blocked the pre-push hook, so the fork agent bypassed its own gate with `git push --no-verify` on both ABCA-487 and ABCA-488 — the exact thing the gate exists to prevent.

## Fix

Test-only: `delete process.env.MEMORY_ID` in `beforeEach` to pin a clean "no ambient memory" baseline. Tests that exercise the memory path pass the `memoryId` option explicitly, so they're unaffected.

## Test

`mise run build` green in `cdk/`: **124 suites / 2261 tests pass**, eslint no mutations.
