### PR TITLE
feat(jira): post final status comments with cost, turns, and duration (#573)

### DIFF
--- a/agent/src/jira_reactions.py
+++ b/agent/src/jira_reactions.py
@@ -1,9 +1,15 @@
 """Jira issue-comment helper for Jira-origin tasks.
 
-Posts a "starting" comment on the originating Jira issue at task start and a
-terminal "succeeded / failed (+ PR link)" comment at the end — the Jira
-analogue of ``linear_reactions`` (Linear uses emoji reactions; Jira's REST
-API has no lightweight reaction primitive, so comments are the right tool).
+Posts a "starting" comment on the originating Jira issue at task start — the
+Jira analogue of ``linear_reactions`` (Linear uses emoji reactions; Jira's
+REST API has no lightweight reaction primitive, so comments are the right
+tool).
+
+The *terminal* status comment is NOT posted from here: since issue #573 the
+deterministic fan-out plane (``cdk/src/handlers/fanout-task-events.ts``
+``dispatchToJira``) owns it, so it carries cost/turns/duration and fires even
+when this agent crashes before completing. This module only owns the start
+comment.
 
 Why a direct REST call instead of MCP: Atlassian's Remote MCP
 (``mcp.atlassian.com``) requires an interactive, browser-based OAuth 2.1
@@ -182,32 +188,13 @@ def comment_task_started(
     log("TASK", f"jira_reactions: comment_task_started issue={issue_key} ok={ok}")
 
 
-def comment_task_finished(
-    channel_source: str,
-    channel_metadata: dict[str, str] | None,
-    success: bool,
-    pr_url: str | None = None,
-) -> None:
-    """Post a terminal status comment on the Jira issue. No-op for non-Jira tasks."""
-    target = _enabled(channel_source, channel_metadata)
-    if not target:
-        return
-    cloud_id, issue_key = target
-    if success:
-        text = "✅ ABCA finished this task."
-        if pr_url:
-            text += f" Pull request: {pr_url}"
-        else:
-            text += " No pull request was opened."
-    else:
-        text = "❌ ABCA could not complete this task. Check the agent logs for details."
-        if pr_url:
-            text += f" A pull request was opened anyway: {pr_url}"
-    ok = _post_comment(cloud_id, issue_key, text)
-    log(
-        "TASK",
-        f"jira_reactions: comment_task_finished issue={issue_key} success={success} ok={ok}",
-    )
+# NOTE: there is deliberately no ``comment_task_finished`` here. Since issue
+# #573 the deterministic fan-out plane
+# (``cdk/src/handlers/fanout-task-events.ts`` ``dispatchToJira``) owns the Jira
+# terminal comment — it carries cost/turns/duration and, crucially, fires even
+# when the agent crashes before completing (max-turns, OOM). The agent only
+# posts the *start* comment (``comment_task_started`` above); posting a terminal
+# comment here too would double-comment on the issue.
 
 
 def _reset_state_for_testing() -> None:

--- a/agent/src/pipeline.py
+++ b/agent/src/pipeline.py
@@ -23,7 +23,7 @@ from config import (
     resolve_linear_api_token,
 )
 from context import assemble_prompt, fetch_github_issue
-from jira_reactions import comment_task_finished, comment_task_started
+from jira_reactions import comment_task_started
 from linear_reactions import react_task_finished, react_task_started
 from models import AgentResult, HydratedContext, RepoSetup, TaskConfig, TaskResult
 from observability import current_otel_trace_id, task_span
@@ -1106,14 +1106,14 @@ def run_task(
                 started_reaction_id=linear_eyes_reaction_id,
             )
 
-            # Terminal status comment on the Jira issue (REST shim, with the
-            # PR link when one was opened). No-op for non-Jira tasks.
-            comment_task_finished(
-                config.channel_source,
-                config.channel_metadata,
-                success=(overall_status == "success"),
-                pr_url=pr_url,
-            )
+            # NOTE: the terminal status comment on the Jira issue is NOT posted
+            # here. Since issue #573 the deterministic fan-out plane
+            # (``cdk/src/handlers/fanout-task-events.ts`` ``dispatchToJira``)
+            # owns the Jira final-status comment — it carries cost/turns/
+            # duration and, crucially, fires even if this agent crashes before
+            # reaching this point (max-turns, OOM). Posting here too would
+            # double-comment. The agent still posts the *start* comment
+            # (``comment_task_started`` above) for in-flight progress.
 
             # --trace trajectory S3 upload (design §10.1). Runs AFTER
             # post-hooks but BEFORE ``write_terminal`` so the resulting
@@ -1244,14 +1244,11 @@ def run_task(
                 success=False,
                 started_reaction_id=linear_eyes_reaction_id,
             )
-            # Best-effort failure comment on the Jira issue. No-op for
-            # non-Jira tasks; network failures are swallowed.
-            comment_task_finished(
-                config.channel_source,
-                config.channel_metadata,
-                success=False,
-                pr_url=None,
-            )
+            # NOTE: no Jira failure comment here — the fan-out plane's
+            # ``dispatchToJira`` (issue #573) owns the Jira terminal comment
+            # and fires on the platform side even when this crash path runs,
+            # so posting here would double-comment. (Contrast the Linear ❌
+            # reaction above, which the fan-out plane does not replicate.)
             raise
 
 

--- a/agent/tests/test_jira_reactions.py
+++ b/agent/tests/test_jira_reactions.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import jira_reactions
-from jira_reactions import comment_task_finished, comment_task_started
+from jira_reactions import comment_task_started
 
 JIRA_META = {"jira_cloud_id": "cloud-1", "jira_issue_key": "KAN-1"}
 
@@ -36,7 +36,6 @@ class TestChannelGate:
         monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
         with patch("jira_reactions.requests.post") as post:
             comment_task_started("linear", JIRA_META)
-            comment_task_finished("linear", JIRA_META, success=True)
             post.assert_not_called()
 
     def test_empty_metadata_is_noop(self, monkeypatch):
@@ -74,31 +73,14 @@ class TestStartComment:
             post.assert_not_called()
 
 
-class TestFinishComment:
-    def test_success_with_pr_includes_pr_url(self, monkeypatch):
-        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
-        with patch("jira_reactions.requests.post", return_value=_resp(201)) as post:
-            comment_task_finished(
-                "jira", JIRA_META, success=True, pr_url="https://github.com/o/r/pull/7"
-            )
-        text = post.call_args[1]["json"]["body"]["content"][0]["content"][0]["text"]
-        assert "✅" in text
-        assert "https://github.com/o/r/pull/7" in text
+class TestTerminalCommentDemoted:
+    """Since issue #573 the fan-out plane (``dispatchToJira``) owns the Jira
+    terminal comment, so the agent no longer exposes ``comment_task_finished``.
+    This pins the demotion so a future refactor can't silently re-introduce a
+    duplicate terminal comment on the agent side."""
 
-    def test_success_without_pr_notes_no_pr(self, monkeypatch):
-        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
-        with patch("jira_reactions.requests.post", return_value=_resp(201)) as post:
-            comment_task_finished("jira", JIRA_META, success=True, pr_url=None)
-        text = post.call_args[1]["json"]["body"]["content"][0]["content"][0]["text"]
-        assert "✅" in text
-        assert "No pull request" in text
-
-    def test_failure_comment(self, monkeypatch):
-        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
-        with patch("jira_reactions.requests.post", return_value=_resp(201)) as post:
-            comment_task_finished("jira", JIRA_META, success=False, pr_url=None)
-        text = post.call_args[1]["json"]["body"]["content"][0]["content"][0]["text"]
-        assert "❌" in text
+    def test_comment_task_finished_is_gone(self):
+        assert not hasattr(jira_reactions, "comment_task_finished")
 
 
 class TestFailureIsSwallowed:
@@ -107,7 +89,6 @@ class TestFailureIsSwallowed:
         with patch("jira_reactions.requests.post", return_value=_resp(500, "boom")):
             # Must not raise.
             comment_task_started("jira", JIRA_META)
-            comment_task_finished("jira", JIRA_META, success=True)
 
     def test_request_exception_does_not_raise(self, monkeypatch):
         import requests
@@ -130,7 +111,7 @@ class TestAuthCircuitBreaker:
             calls_after_open = post.call_count
             # Further calls short-circuit without hitting the network.
             comment_task_started("jira", JIRA_META)
-            comment_task_finished("jira", JIRA_META, success=True)
+            comment_task_started("jira", JIRA_META)
             assert post.call_count == calls_after_open
 
     def test_2xx_resets_failure_counter(self, monkeypatch):

--- a/cdk/src/constructs/fanout-consumer.ts
+++ b/cdk/src/constructs/fanout-consumer.ts
@@ -107,6 +107,27 @@ export interface FanOutConsumerProps {
   readonly linearOauthSecretArnPattern?: string;
 
   /**
+   * JiraWorkspaceRegistryTable — the Jira dispatcher reads this to resolve
+   * per-tenant OAuth tokens at comment-post time (issue #573). Optional:
+   * when omitted, the dispatcher logs and skips so a deployment without
+   * Jira onboarding doesn't accumulate dangling IAM grants. Mirrors
+   * ``linearWorkspaceRegistryTable``.
+   */
+  readonly jiraWorkspaceRegistryTable?: dynamodb.ITable;
+
+  /**
+   * Secrets Manager ARN-prefix pattern for per-tenant Jira OAuth bundles.
+   * Mirrors ``linearOauthSecretArnPattern`` — typically
+   * ``bgagent-jira-oauth-*``. Required when ``jiraWorkspaceRegistryTable``
+   * is set; without it the dispatcher would resolve the registry row but
+   * fail at the SM GetSecretValue call. GetSecretValue + PutSecretValue
+   * because the resolver rotates an expiring token in place (the fan-out
+   * Lambda is trusted stack code, same as the orchestrator + webhook
+   * processor).
+   */
+  readonly jiraOauthSecretArnPattern?: string;
+
+  /**
    * Maximum batch size delivered to the Lambda per invocation.
    *
    * @default 100 (DynamoDB Stream default)
@@ -231,6 +252,29 @@ export class FanOutConsumer extends Construct {
       }));
     }
 
+    // Jira dispatcher plumbing (issue #573). Same guarded shape as Linear:
+    // a deployment without Jira onboarding gets no IAM grants and the
+    // dispatcher logs-and-skips on missing env. The registry table resolves
+    // the per-tenant OAuth-secret ARN; the secret holds the access token
+    // ``postIssueCommentAdf`` uses to POST the final-status comment via the
+    // Jira REST v3 API.
+    if (props.jiraWorkspaceRegistryTable) {
+      props.jiraWorkspaceRegistryTable.grantReadData(this.fn);
+      this.fn.addEnvironment(
+        'JIRA_WORKSPACE_REGISTRY_TABLE_NAME',
+        props.jiraWorkspaceRegistryTable.tableName,
+      );
+    }
+    if (props.jiraOauthSecretArnPattern) {
+      this.fn.addToRolePolicy(new iam.PolicyStatement({
+        // GetSecretValue + PutSecretValue: resolving an expiring token
+        // refreshes it in place — same grants the orchestrator + Jira
+        // webhook-processor Lambdas hold.
+        actions: ['secretsmanager:GetSecretValue', 'secretsmanager:PutSecretValue'],
+        resources: [props.jiraOauthSecretArnPattern],
+      }));
+    }
+
     // Alarm on any record landing in the DLQ. Notifications are
     // best-effort by design, so individual failures don't fail the
     // batch — which means the DLQ is the ONLY persistent signal of a
@@ -244,7 +288,7 @@ export class FanOutConsumer extends Construct {
       threshold: 1,
       evaluationPeriods: 1,
       alarmDescription:
-        'Fan-out DLQ has undelivered task-event records — Slack/GitHub/Linear notifications are failing',
+        'Fan-out DLQ has undelivered task-event records — Slack/GitHub/Linear/Jira notifications are failing',
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
     });
 

--- a/cdk/src/handlers/fanout-task-events.ts
+++ b/cdk/src/handlers/fanout-task-events.ts
@@ -1204,9 +1204,15 @@ export function renderJiraFinalStatusComment(args: {
   // Render the PR link whenever one exists — on both the ✅ success path and
   // the ⚠️ shipped-but-stopped path. This diverges from Linear (which omits
   // it on success) because Jira no longer has the agent-side terminal
-  // comment carrying the link (issue #573 decision).
+  // comment carrying the link (issue #573 decision). The URL run carries an
+  // ``href`` so it renders as a clickable hyperlink — ADF does not
+  // auto-linkify a bare URL in a plain text node the way Linear's Markdown
+  // does, so without this the requester would have to copy-paste it.
   if (args.prUrl) {
-    paragraphs.push([{ text: `PR: ${args.prUrl}` }]);
+    paragraphs.push([
+      { text: 'PR: ' },
+      { text: args.prUrl, href: args.prUrl },
+    ]);
   }
   paragraphs.push([{ text: `task ${args.taskId}`, em: true }]);
   return paragraphs;

--- a/cdk/src/handlers/fanout-task-events.ts
+++ b/cdk/src/handlers/fanout-task-events.ts
@@ -48,6 +48,11 @@ import type {
 import { clearTokenCache, resolveGitHubToken } from './shared/context-hydration';
 import { classifyError } from './shared/error-classifier';
 import { renderCommentBody, upsertTaskComment } from './shared/github-comment';
+import {
+  buildAdfDocument,
+  postIssueCommentAdf,
+  type AdfParagraph,
+} from './shared/jira-feedback';
 import { postIssueComment } from './shared/linear-feedback';
 import { logger } from './shared/logger';
 import { coerceNumericOrNull } from './shared/numeric';
@@ -107,7 +112,7 @@ const APPROVAL_NOTIFICATION_EVENTS = [
  *   - Per-user rate limit of 10 approval-related messages per minute
  *     is enforced in the dispatcher, not in this filter.
  */
-export type NotificationChannel = 'slack' | 'email' | 'github' | 'linear';
+export type NotificationChannel = 'slack' | 'email' | 'github' | 'linear' | 'jira';
 
 export const CHANNEL_DEFAULTS: Record<NotificationChannel, ReadonlySet<string>> = {
   // Slack is the "on-call" channel per §6.2 — all terminal outcomes
@@ -171,6 +176,26 @@ export const CHANNEL_DEFAULTS: Record<NotificationChannel, ReadonlySet<string>> 
   // are excluded for the same reason — N comments rather than 1.
   linear: new Set<string>([
     ...TERMINAL_EVENT_TYPES,
+  ]),
+  // Jira posts a single deterministic final-status comment on terminal
+  // events — the Jira analogue of the Linear default above (issue #573).
+  // Before this, Jira-origin tasks relied solely on the agent-side
+  // ``jira_reactions.py`` terminal comment, which only carried
+  // success/failure + PR URL and never fired at all if the agent crashed
+  // before reaching its final-comment path (max-turns, OOM). This
+  // dispatcher owns the terminal comment instead — with cost / turns /
+  // duration — and fires even on an agent crash. ``task_timed_out`` is
+  // included (unlike Linear, which predates it) because the orchestrator
+  // now emits it as a distinct terminal event (``orchestrator.ts``); the
+  // Slack + email defaults already subscribe to it.
+  //
+  // Jira has no comment-edit API (same as Linear), so this is post-once:
+  // idempotency across partial-batch retries rides on the
+  // ``jira_final_comment_event_id`` marker. The agent-side start comment
+  // ("🤖 ABCA picked up this issue…") stays for in-flight progress.
+  jira: new Set<string>([
+    ...TERMINAL_EVENT_TYPES,
+    'task_timed_out',
   ]),
 };
 
@@ -574,6 +599,24 @@ async function saveLinearCommentState(taskId: string, eventId: string): Promise<
     values: { ':eid': eventId },
     channel: 'linear',
     errorId: 'FANOUT_LINEAR_PERSIST_FAILED',
+    logContext: { event_id: eventId },
+  });
+}
+
+/**
+ * Persist the post-once marker after a successful Jira final-status comment
+ * (see ``dispatchToJira``). The Jira analogue of ``saveLinearCommentState`` —
+ * Jira has no comment-edit API, so the marker is what makes the post
+ * idempotent across partial-batch retries.
+ */
+async function saveJiraCommentState(taskId: string, eventId: string): Promise<void> {
+  await saveDispatchMarker({
+    taskId,
+    updateExpression: 'SET jira_final_comment_event_id = :eid',
+    conditionExpression: 'attribute_exists(task_id) AND attribute_not_exists(jira_final_comment_event_id)',
+    values: { ':eid': eventId },
+    channel: 'jira',
+    errorId: 'FANOUT_JIRA_PERSIST_FAILED',
     logContext: { event_id: eventId },
   });
 }
@@ -1101,6 +1144,226 @@ async function dispatchToLinear(event: FanOutEvent): Promise<void> {
   }
 }
 
+/**
+ * Render the Jira final-status comment as ADF paragraphs. Mirrors
+ * ``renderLinearFinalStatusComment`` framing exactly — the only difference
+ * is the output shape (ADF runs vs Markdown string), because Jira REST v3
+ * comments require Atlassian Document Format, not Markdown.
+ *
+ * Three outcomes based on ``(eventType, prUrl)``:
+ *
+ *   1. ``task_completed``                        → ✅ "Task completed"
+ *   2. any non-completed terminal event WITH PR  → ⚠️ "Shipped a PR but stopped early"
+ *   3. any non-completed terminal event NO PR    → ❌ "Task <subtype>" + classifier title
+ *
+ * Unlike Linear, the PR URL is rendered on the ✅ success path too (issue
+ * #573 decision): demoting the agent-side ``jira_reactions.py`` terminal
+ * comment to this dispatcher removes Jira's only other surviving PR-link
+ * surface, whereas Linear keeps the agent's step-2 "PR opened" comment.
+ *
+ * Missing metric values render as ``—``. The result is a list of ADF
+ * paragraphs (blank lines are empty paragraphs — ADF text nodes do not
+ * honor ``\n``), fed to ``buildAdfDocument``.
+ */
+export function renderJiraFinalStatusComment(args: {
+  eventType: string;
+  prUrl: string | null;
+  costUsd: number | null;
+  turns: number | null;
+  maxTurns: number | null;
+  durationS: number | null;
+  taskId: string;
+  errorTitle: string | null;
+}): ReadonlyArray<AdfParagraph> {
+  const isCompleted = args.eventType === 'task_completed';
+  const shippedDespiteFailure = !isCompleted && args.prUrl != null;
+
+  let header: string;
+  if (isCompleted) {
+    header = '✅ Task completed';
+  } else if (shippedDespiteFailure) {
+    const reason = args.errorTitle ? ` — ${args.errorTitle}` : '';
+    header = `⚠️ Shipped a PR but stopped early${reason} — review and decide if more work is needed`;
+  } else {
+    const reason = args.errorTitle ? `: ${args.errorTitle}` : '';
+    header = `❌ Task ${args.eventType.replace(/^task_/, '')}${reason}`;
+  }
+
+  const costStr = args.costUsd != null ? `$${args.costUsd.toFixed(2)}` : '—';
+  const turnsStr = args.turns != null
+    ? `${args.turns}${args.maxTurns != null ? ` / ${args.maxTurns}` : ''}`
+    : '—';
+  const durationStr = args.durationS != null
+    ? formatDuration(args.durationS)
+    : '—';
+
+  const paragraphs: AdfParagraph[] = [
+    [{ text: header, strong: true }],
+    [{ text: `cost: ${costStr} • turns: ${turnsStr} • duration: ${durationStr}` }],
+  ];
+  // Render the PR link whenever one exists — on both the ✅ success path and
+  // the ⚠️ shipped-but-stopped path. This diverges from Linear (which omits
+  // it on success) because Jira no longer has the agent-side terminal
+  // comment carrying the link (issue #573 decision).
+  if (args.prUrl) {
+    paragraphs.push([{ text: `PR: ${args.prUrl}` }]);
+  }
+  paragraphs.push([{ text: `task ${args.taskId}`, em: true }]);
+  return paragraphs;
+}
+
+/**
+ * Jira dispatcher — posts a deterministic final-status comment when a
+ * Jira-origin task reaches a terminal event. The Jira analogue of
+ * ``dispatchToLinear`` (issue #573); structurally identical:
+ *
+ *   1. Guard on ``JIRA_WORKSPACE_REGISTRY_TABLE_NAME`` (deploy-misconfig).
+ *   2. Load TaskRecord. Skip if missing (TTL eviction race).
+ *   3. Gate on ``channel_source === 'jira'`` so non-Jira tasks short-circuit
+ *      after one DDB Get.
+ *   4. Read ``jira_cloud_id`` + ``jira_issue_key`` from ``channel_metadata``.
+ *      Skip if either is missing — defensive; shouldn't happen for a
+ *      properly-admitted Jira task.
+ *   5. Idempotency: skip if the ``jira_final_comment_event_id`` marker is set.
+ *   6. Render ADF + post via ``postIssueCommentAdf`` (which owns the
+ *      OAuth-refresh-and-retry-once behaviour), then persist the marker.
+ *
+ * Failure handling matches Linear: terminal failures log-and-resolve (a
+ * retry cannot fix a revoked tenant or bad issue key); retryable failures
+ * THROW so ``routeEvent`` records an infra rejection and the record lands
+ * in ``batchItemFailures`` for a Lambda retry. The retry is idempotent —
+ * the marker is persisted only after a successful post.
+ */
+async function dispatchToJira(event: FanOutEvent): Promise<void> {
+  const registryTableName = process.env.JIRA_WORKSPACE_REGISTRY_TABLE_NAME;
+  if (!registryTableName) {
+    // WARN with error_id so this is alarmable — same shape as the Linear
+    // dispatcher. The final-status comment is the only completion signal
+    // that survives an agent crash, so a misconfigured env var would
+    // silently drop every Jira-origin task's metrics.
+    logger.warn('[fanout/jira] JIRA_WORKSPACE_REGISTRY_TABLE_NAME not set — skipping', {
+      event: 'fanout.jira.missing_env',
+      error_id: 'FANOUT_JIRA_MISSING_ENV',
+      task_id: event.task_id,
+    });
+    return;
+  }
+
+  const task = await loadTaskForComment(event.task_id);
+  if (!task) {
+    logger.warn('[fanout/jira] task not found — skipping comment', {
+      event: 'fanout.jira.task_missing',
+      task_id: event.task_id,
+    });
+    return;
+  }
+
+  // channel_source gate — short-circuit non-Jira tasks after one DDB Get.
+  if (task.channel_source !== 'jira') {
+    return;
+  }
+
+  const cloudId = task.channel_metadata?.jira_cloud_id;
+  const issueKey = task.channel_metadata?.jira_issue_key;
+  if (!cloudId || !issueKey) {
+    logger.warn('[fanout/jira] task missing jira_cloud_id or jira_issue_key — skipping', {
+      event: 'fanout.jira.metadata_missing',
+      task_id: event.task_id,
+      has_cloud_id: Boolean(cloudId),
+      has_issue_key: Boolean(issueKey),
+    });
+    return;
+  }
+
+  // Idempotency across partial-batch retries: Jira has no comment edit API,
+  // so a re-run (e.g. a sibling channel's infra rejection pushed the whole
+  // stream record into batchItemFailures) would post a duplicate. The
+  // marker is persisted after the first successful post below.
+  if (task.jira_final_comment_event_id) {
+    logger.info('[fanout/jira] final comment already posted — skipping (idempotent retry)', {
+      event: 'fanout.jira.already_posted',
+      task_id: task.task_id,
+      posted_event_id: task.jira_final_comment_event_id,
+      event_id: event.event_id,
+    });
+    return;
+  }
+
+  // Same classifier the Linear dispatcher + API surface use — "Hit max-turns
+  // cap", "Insufficient GitHub permissions", etc. Returns null only when
+  // error_message is empty (the task_completed case).
+  const classification = classifyError(task.error_message);
+
+  const paragraphs = renderJiraFinalStatusComment({
+    eventType: event.event_type,
+    prUrl: task.pr_url ?? null,
+    // DDB returns numeric attributes as strings at the Document-client
+    // boundary; coerce so toFixed/comparisons work. Same pattern the
+    // GitHub + Linear dispatchers use.
+    costUsd: coerceNumericOrNull(
+      task.cost_usd,
+      { field: 'cost_usd', task_id: task.task_id, event_id: event.event_id },
+      logger,
+    ),
+    turns: coerceNumericOrNull(
+      task.turns_attempted,
+      { field: 'turns_attempted', task_id: task.task_id, event_id: event.event_id },
+      logger,
+    ),
+    maxTurns: coerceNumericOrNull(
+      task.max_turns,
+      { field: 'max_turns', task_id: task.task_id, event_id: event.event_id },
+      logger,
+    ),
+    durationS: coerceNumericOrNull(
+      task.duration_s,
+      { field: 'duration_s', task_id: task.task_id, event_id: event.event_id },
+      logger,
+    ),
+    taskId: task.task_id,
+    errorTitle: classification?.title ?? null,
+  });
+
+  const postResult = await postIssueCommentAdf(
+    { cloudId, registryTableName },
+    issueKey,
+    buildAdfDocument(paragraphs),
+  );
+
+  if (postResult.ok) {
+    logger.info('[fanout/jira] comment dispatched', {
+      event: 'fanout.jira.dispatched',
+      task_id: task.task_id,
+      jira_cloud_id: cloudId,
+      jira_issue_key: issueKey,
+      event_type: event.event_type,
+      posted: true,
+    });
+    await saveJiraCommentState(task.task_id, event.event_id);
+  } else {
+    logger.warn('[fanout/jira] postIssueCommentAdf failed — Jira REST path failed', {
+      event: 'fanout.jira.post_failed',
+      error_id: 'FANOUT_JIRA_POST_FAILED',
+      task_id: task.task_id,
+      jira_cloud_id: cloudId,
+      jira_issue_key: issueKey,
+      event_type: event.event_type,
+      posted: false,
+      retryable: postResult.retryable,
+    });
+    if (postResult.retryable) {
+      // Escalate to routeEvent's Promise.allSettled so the record enters
+      // batchItemFailures and Lambda retries. Safe because the marker above
+      // was NOT persisted — the retry posts the missing comment or, if a
+      // concurrent run won, short-circuits on the marker. Terminal failures
+      // stay log-only: a retry cannot fix them.
+      throw new Error(
+        `[fanout/jira] transient Jira post failure for task ${task.task_id} — escalating for batch retry`,
+      );
+    }
+  }
+}
+
 /** Exposed for testing: the per-channel dispatcher callable by the
  *  handler. Each key's absence from the routing map disables its
  *  dispatcher; the signature is uniform so adding a channel is one
@@ -1109,6 +1372,7 @@ const DISPATCHERS: Record<NotificationChannel, (ev: FanOutEvent) => Promise<void
   slack: dispatchToSlack,
   github: dispatchToGitHubComment,
   linear: dispatchToLinear,
+  jira: dispatchToJira,
   email: dispatchToEmail,
 };
 
@@ -1163,8 +1427,8 @@ export async function routeEvent(
     attempted.push(ch);
     tasks.push(DISPATCHERS[ch](ev));
   }
-  // Parallelism is bounded by the dispatcher list (4 channels:
-  // slack/github/linear/email), not by program input, so the
+  // Parallelism is bounded by the dispatcher list (5 channels:
+  // slack/github/linear/jira/email), not by program input, so the
   // unbounded-parallelism lint does not apply.
 
   const results = await Promise.allSettled(tasks);

--- a/cdk/src/handlers/fanout-task-events.ts
+++ b/cdk/src/handlers/fanout-task-events.ts
@@ -52,6 +52,7 @@ import {
   buildAdfDocument,
   postIssueCommentAdf,
   type AdfParagraph,
+  type AdfTextRun,
 } from './shared/jira-feedback';
 import { postIssueComment } from './shared/linear-feedback';
 import { logger } from './shared/logger';
@@ -1146,9 +1147,9 @@ async function dispatchToLinear(event: FanOutEvent): Promise<void> {
 
 /**
  * Render the Jira final-status comment as ADF paragraphs. Mirrors
- * ``renderLinearFinalStatusComment`` framing exactly — the only difference
- * is the output shape (ADF runs vs Markdown string), because Jira REST v3
- * comments require Atlassian Document Format, not Markdown.
+ * ``renderLinearFinalStatusComment`` framing — the difference is the output
+ * shape (ADF runs vs Markdown string), because Jira REST v3 comments require
+ * Atlassian Document Format, not Markdown.
  *
  * Three outcomes based on ``(eventType, prUrl)``:
  *
@@ -1156,10 +1157,11 @@ async function dispatchToLinear(event: FanOutEvent): Promise<void> {
  *   2. any non-completed terminal event WITH PR  → ⚠️ "Shipped a PR but stopped early"
  *   3. any non-completed terminal event NO PR    → ❌ "Task <subtype>" + classifier title
  *
- * Unlike Linear, the PR URL is rendered on the ✅ success path too (issue
- * #573 decision): demoting the agent-side ``jira_reactions.py`` terminal
- * comment to this dispatcher removes Jira's only other surviving PR-link
- * surface, whereas Linear keeps the agent's step-2 "PR opened" comment.
+ * The PR URL is rendered on the ✅ success path too — not just the ⚠️ path —
+ * because the agent's own "PR opened" comment is not guaranteed to have fired
+ * (a decompose→single task, or an agent that skipped that step), so the
+ * platform comment must always carry the link or it can be lost entirely
+ * (ABCA-584). The same fix lands for Linear in #601.
  *
  * Missing metric values render as ``—``. The result is a list of ADF
  * paragraphs (blank lines are empty paragraphs — ADF text nodes do not
@@ -1178,15 +1180,28 @@ export function renderJiraFinalStatusComment(args: {
   const isCompleted = args.eventType === 'task_completed';
   const shippedDespiteFailure = !isCompleted && args.prUrl != null;
 
-  let header: string;
+  // Header runs. Bold scope mirrors Linear's Markdown: the ⚠️ frame bolds
+  // only through the reason and leaves the trailing "review and decide…"
+  // advice unbolded, so it's a two-run paragraph. The ✅ / ❌ frames are a
+  // single bold run.
+  let headerRuns: AdfTextRun[];
   if (isCompleted) {
-    header = '✅ Task completed';
+    headerRuns = [{ text: '✅ Task completed', strong: true }];
   } else if (shippedDespiteFailure) {
     const reason = args.errorTitle ? ` — ${args.errorTitle}` : '';
-    header = `⚠️ Shipped a PR but stopped early${reason} — review and decide if more work is needed`;
+    headerRuns = [
+      { text: `⚠️ Shipped a PR but stopped early${reason}`, strong: true },
+      { text: ' — review and decide if more work is needed' },
+    ];
   } else {
+    // Humanize the event subtype for the header: strip the ``task_`` prefix
+    // and turn underscores into spaces so ``task_timed_out`` reads "Task
+    // timed out" rather than the raw "Task timed_out". Jira is the only
+    // channel routing ``task_timed_out`` through this renderer, so this
+    // multi-word subtype is a case the copied-from-Linear code never hit.
+    const subtype = args.eventType.replace(/^task_/, '').replace(/_/g, ' ');
     const reason = args.errorTitle ? `: ${args.errorTitle}` : '';
-    header = `❌ Task ${args.eventType.replace(/^task_/, '')}${reason}`;
+    headerRuns = [{ text: `❌ Task ${subtype}${reason}`, strong: true }];
   }
 
   const costStr = args.costUsd != null ? `$${args.costUsd.toFixed(2)}` : '—';
@@ -1198,16 +1213,16 @@ export function renderJiraFinalStatusComment(args: {
     : '—';
 
   const paragraphs: AdfParagraph[] = [
-    [{ text: header, strong: true }],
+    headerRuns,
     [{ text: `cost: ${costStr} • turns: ${turnsStr} • duration: ${durationStr}` }],
   ];
   // Render the PR link whenever one exists — on both the ✅ success path and
-  // the ⚠️ shipped-but-stopped path. This diverges from Linear (which omits
-  // it on success) because Jira no longer has the agent-side terminal
-  // comment carrying the link (issue #573 decision). The URL run carries an
-  // ``href`` so it renders as a clickable hyperlink — ADF does not
-  // auto-linkify a bare URL in a plain text node the way Linear's Markdown
-  // does, so without this the requester would have to copy-paste it.
+  // the ⚠️ shipped-but-stopped path — because the agent's own "PR opened"
+  // comment may not have fired (ABCA-584), so this is the only guaranteed
+  // PR-link surface. The URL run carries an ``href`` so it renders as a
+  // clickable hyperlink — ADF does not auto-linkify a bare URL in a plain
+  // text node the way Linear's Markdown does, so without this the requester
+  // would have to copy-paste it.
   if (args.prUrl) {
     paragraphs.push([
       { text: 'PR: ' },

--- a/cdk/src/handlers/shared/jira-feedback.ts
+++ b/cdk/src/handlers/shared/jira-feedback.ts
@@ -67,17 +67,82 @@ function toAdfDocument(message: string): Record<string, unknown> {
 }
 
 /**
+ * A single run of comment text with optional inline emphasis. The ADF
+ * serializer ({@link buildAdfDocument}) maps ``strong``/``em`` onto ADF
+ * ``marks``. Callers that need plain text simply omit both flags. This is
+ * the smallest content model that lets the fan-out final-status comment
+ * render a bold header + italic task-id footer without hand-building ADF
+ * at every call site (issue #573).
+ */
+export interface AdfTextRun {
+  readonly text: string;
+  readonly strong?: boolean;
+  readonly em?: boolean;
+}
+
+/** A paragraph is a list of runs; an empty run list renders a blank line. */
+export type AdfParagraph = ReadonlyArray<AdfTextRun>;
+
+/**
+ * Build a multi-paragraph ADF document. Each element of ``paragraphs``
+ * becomes one ADF ``paragraph`` node; an empty run list yields an empty
+ * paragraph (Jira renders it as a blank line, which is how we get the
+ * spacing between the header, the metrics line, and the footer without
+ * embedding ``\n`` — ADF text nodes do not honor newlines).
+ *
+ * Exported for the fan-out final-status renderer + its tests. The
+ * single-paragraph {@link toAdfDocument} stays for the short processor
+ * messages that have no structure to preserve.
+ */
+export function buildAdfDocument(paragraphs: ReadonlyArray<AdfParagraph>): Record<string, unknown> {
+  return {
+    type: 'doc',
+    version: 1,
+    content: paragraphs.map((runs) => ({
+      type: 'paragraph',
+      content: runs.map((run) => {
+        const marks: Array<{ type: string }> = [];
+        if (run.strong) marks.push({ type: 'strong' });
+        if (run.em) marks.push({ type: 'em' });
+        return marks.length > 0
+          ? { type: 'text', text: run.text, marks }
+          : { type: 'text', text: run.text };
+      }),
+    })),
+  };
+}
+
+/**
+ * Classified outcome of a comment POST, mirroring Linear's
+ * ``LinearPostResult``. ``retryable`` distinguishes transient failures
+ * (network error, request timeout, HTTP 5xx/429) — where a Lambda retry
+ * may genuinely succeed — from terminal ones (bad issue id, revoked
+ * credential, malformed request) where it cannot. The best-effort
+ * boolean-returning {@link postIssueComment} collapses this to
+ * ``ok``/``!ok``; the fan-out dispatcher branches on ``retryable`` to
+ * decide whether to escalate to the partial-batch retry path (#573).
+ */
+export type JiraPostResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly retryable: boolean };
+
+/**
  * Outcome of a single comment POST. We distinguish auth rejection (401/403)
  * from other failures so the caller can react to the former with a forced
- * token refresh + retry, and treat the latter as terminal.
+ * token refresh + retry. Non-auth failures carry a ``retryable`` flag so the
+ * classified caller ({@link postCommentWithResult}) can tell a transient
+ * 5xx/429/network blip from a terminal 4xx.
  */
-type PostOutcome = 'ok' | 'auth' | 'error';
+type PostOutcome =
+  | { readonly kind: 'ok' }
+  | { readonly kind: 'auth' }
+  | { readonly kind: 'error'; readonly retryable: boolean };
 
 async function postComment(
   accessToken: string,
   cloudId: string,
   issueIdOrKey: string,
-  message: string,
+  body: Record<string, unknown>,
 ): Promise<PostOutcome> {
   // The 3LO token (audience=api.atlassian.com) is only valid against the
   // gateway base scoped by cloudId — see JIRA_API_BASE. Posting to the raw
@@ -96,23 +161,32 @@ async function postComment(
         'Content-Type': 'application/json',
         'Accept': 'application/json',
       },
-      body: JSON.stringify({ body: toAdfDocument(message) }),
+      body: JSON.stringify({ body }),
       signal: controller.signal,
     });
-    if (resp.ok) return 'ok';
-    // 401/403 are recoverable: the stored access token may be dead despite a
-    // not-yet-reached `expires_at` (server-side revocation, scope re-issue, or
-    // a value cached past its out-of-band rotation). Signal the caller to
-    // force-refresh and retry once. Any other non-2xx is terminal.
-    const outcome: PostOutcome = resp.status === 401 || resp.status === 403 ? 'auth' : 'error';
-    logger.warn('Jira feedback REST non-2xx', { status: resp.status, url, outcome });
-    return outcome;
+    if (resp.ok) return { kind: 'ok' };
+    // 401/403 are recoverable via a forced refresh: the stored access token
+    // may be dead despite a not-yet-reached `expires_at` (server-side
+    // revocation, scope re-issue, or a value cached past its out-of-band
+    // rotation). Signal the caller to force-refresh and retry once. 5xx is a
+    // Jira-side outage and 429 a rate limit — both may clear on a Lambda
+    // retry. Any other non-2xx (400/404…) is terminal: re-sending the same
+    // request cannot change the answer.
+    if (resp.status === 401 || resp.status === 403) {
+      logger.warn('Jira feedback REST auth rejection', { status: resp.status, url });
+      return { kind: 'auth' };
+    }
+    const retryable = resp.status >= 500 || resp.status === 429;
+    logger.warn('Jira feedback REST non-2xx', { status: resp.status, url, retryable });
+    return { kind: 'error', retryable };
   } catch (err) {
+    // fetch rejection: DNS/connect failure or the AbortController timeout —
+    // transient by nature, so worth a retry.
     logger.warn('Jira feedback request failed', {
       error: err instanceof Error ? err.message : String(err),
       url,
     });
-    return 'error';
+    return { kind: 'error', retryable: true };
   } finally {
     clearTimeout(timer);
   }
@@ -174,22 +248,55 @@ export async function postIssueComment(
   issueIdOrKey: string,
   body: string,
 ): Promise<boolean> {
+  const result = await postCommentWithResult(ctx, issueIdOrKey, toAdfDocument(body));
+  return result.ok;
+}
+
+/**
+ * Post a pre-built ADF document onto a Jira issue, returning a classified
+ * {@link JiraPostResult} so a caller with a retry mechanism (the fan-out
+ * dispatcher's partial-batch path, #573) can distinguish transient failures
+ * worth a Lambda retry from terminal ones. Never throws.
+ *
+ * Shares the 401/403 forced-refresh-and-retry-once behaviour with
+ * {@link postIssueComment} (issue #370). The auth-refresh path always
+ * classifies its final failure as terminal ``{ retryable: false }`` — a
+ * bad/revoked credential is not fixed by re-running the whole dispatcher.
+ */
+export async function postIssueCommentAdf(
+  ctx: JiraFeedbackContext,
+  issueIdOrKey: string,
+  body: Record<string, unknown>,
+): Promise<JiraPostResult> {
+  return postCommentWithResult(ctx, issueIdOrKey, body);
+}
+
+async function postCommentWithResult(
+  ctx: JiraFeedbackContext,
+  issueIdOrKey: string,
+  body: Record<string, unknown>,
+): Promise<JiraPostResult> {
   const resolved = await resolveTenantToken(ctx);
-  if (!resolved) return false;
+  // Token resolution collapses every failure cause (registry miss, revoked
+  // workspace, unreadable secret, transient DDB/SM throttle) into null. As
+  // with linear-feedback, there is no signal left to tell a throttle from an
+  // unregistered workspace, so we classify it terminal — the dispatcher's
+  // marker-gated retry would not resolve a genuinely-missing credential.
+  if (!resolved) return { ok: false, retryable: false };
 
   const outcome = await postComment(resolved.accessToken, ctx.cloudId, issueIdOrKey, body);
-  if (outcome === 'ok') return true;
-  if (outcome === 'error') return false;
+  if (outcome.kind === 'ok') return { ok: true };
+  if (outcome.kind === 'error') return { ok: false, retryable: outcome.retryable };
 
-  // outcome === 'auth': the stored access token was rejected. Force a refresh
-  // (bypassing the resolver's cache and proactive-expiry short-circuit) and
-  // retry once with the freshly-minted token.
+  // outcome.kind === 'auth': the stored access token was rejected. Force a
+  // refresh (bypassing the resolver's cache and proactive-expiry
+  // short-circuit) and retry once with the freshly-minted token.
   logger.info('Jira feedback got auth rejection — forcing token refresh and retrying once', {
     jira_cloud_id: ctx.cloudId,
     issue_id_or_key: issueIdOrKey,
   });
   const refreshed = await resolveTenantToken(ctx, true);
-  if (!refreshed) return false;
+  if (!refreshed) return { ok: false, retryable: false };
   // If the refresh handed back the same access token, the retry can only
   // reproduce the 401 — skip the redundant network call.
   if (refreshed.accessToken === resolved.accessToken) {
@@ -197,9 +304,15 @@ export async function postIssueComment(
       jira_cloud_id: ctx.cloudId,
       issue_id_or_key: issueIdOrKey,
     });
-    return false;
+    return { ok: false, retryable: false };
   }
-  return (await postComment(refreshed.accessToken, ctx.cloudId, issueIdOrKey, body)) === 'ok';
+  const retryOutcome = await postComment(refreshed.accessToken, ctx.cloudId, issueIdOrKey, body);
+  if (retryOutcome.kind === 'ok') return { ok: true };
+  // A second auth rejection means the credential is genuinely unusable —
+  // terminal. A transient error on the retry stays retryable so the
+  // dispatcher can escalate for a Lambda retry.
+  if (retryOutcome.kind === 'error') return { ok: false, retryable: retryOutcome.retryable };
+  return { ok: false, retryable: false };
 }
 
 /**

--- a/cdk/src/handlers/shared/jira-feedback.ts
+++ b/cdk/src/handlers/shared/jira-feedback.ts
@@ -67,17 +67,24 @@ function toAdfDocument(message: string): Record<string, unknown> {
 }
 
 /**
- * A single run of comment text with optional inline emphasis. The ADF
- * serializer ({@link buildAdfDocument}) maps ``strong``/``em`` onto ADF
- * ``marks``. Callers that need plain text simply omit both flags. This is
- * the smallest content model that lets the fan-out final-status comment
- * render a bold header + italic task-id footer without hand-building ADF
- * at every call site (issue #573).
+ * A single run of comment text with optional inline emphasis / hyperlink.
+ * The ADF serializer ({@link buildAdfDocument}) maps ``strong``/``em`` onto
+ * ADF ``marks`` and ``href`` onto an ADF ``link`` mark. Callers that need
+ * plain text simply omit all flags. This is the smallest content model that
+ * lets the fan-out final-status comment render a bold header, an italic
+ * task-id footer, and a clickable PR link without hand-building ADF at every
+ * call site (issue #573).
+ *
+ * ``href`` matters because ADF — unlike Linear's Markdown — does NOT
+ * auto-linkify a bare URL sitting in a plain text node: it renders as
+ * unclickable text unless the run carries an explicit ``link`` mark.
  */
 export interface AdfTextRun {
   readonly text: string;
   readonly strong?: boolean;
   readonly em?: boolean;
+  /** When set, the run renders as a clickable hyperlink to this URL. */
+  readonly href?: string;
 }
 
 /** A paragraph is a list of runs; an empty run list renders a blank line. */
@@ -101,9 +108,12 @@ export function buildAdfDocument(paragraphs: ReadonlyArray<AdfParagraph>): Recor
     content: paragraphs.map((runs) => ({
       type: 'paragraph',
       content: runs.map((run) => {
-        const marks: Array<{ type: string }> = [];
+        const marks: Array<Record<string, unknown>> = [];
         if (run.strong) marks.push({ type: 'strong' });
         if (run.em) marks.push({ type: 'em' });
+        // ADF ``link`` mark — the only way to make a URL clickable in a
+        // Jira comment; a bare URL in a text node stays plain text.
+        if (run.href) marks.push({ type: 'link', attrs: { href: run.href } });
         return marks.length > 0
           ? { type: 'text', text: run.text, marks }
           : { type: 'text', text: run.text };

--- a/cdk/src/handlers/shared/types.ts
+++ b/cdk/src/handlers/shared/types.ts
@@ -175,6 +175,16 @@ export interface TaskRecord {
    * record). Absent until the first successful post.
    */
   readonly linear_final_comment_event_id?: string;
+  /**
+   * Event ID of the terminal event whose Jira final-status comment was
+   * successfully posted (fan-out plane). Jira has no comment edit API,
+   * so the dispatcher is post-once: this marker makes the post
+   * idempotent across partial-batch Lambda retries (a sibling channel's
+   * infra rejection re-runs every dispatcher for the record). The Jira
+   * analogue of ``linear_final_comment_event_id``. Absent until the
+   * first successful post.
+   */
+  readonly jira_final_comment_event_id?: string;
   readonly attachments?: AttachmentRecord[];
   /**
    * Cedar HITL: per-task default approval timeout (design §10.2).
@@ -239,6 +249,7 @@ export interface TaskNotificationsConfig {
   readonly email?: ChannelConfig;
   readonly github?: ChannelConfig;
   readonly linear?: ChannelConfig;
+  readonly jira?: ChannelConfig;
 }
 
 /**

--- a/cdk/src/stacks/agent.ts
+++ b/cdk/src/stacks/agent.ts
@@ -914,9 +914,10 @@ export class AgentStack extends Stack {
     // Slack / GitHub / Linear / email per per-channel default filters.
     // GitHub dispatcher edits a single issue comment in place; Slack
     // dispatcher (issue #64) reads per-workspace bot tokens from
-    // ``bgagent/slack/*``; Linear dispatcher (issue #239) posts a single
-    // deterministic final-status comment with cost/turns/duration.
-    // Email remains a log-only stub until SES wires.
+    // ``bgagent/slack/*``; Linear dispatcher (issue #239) + Jira dispatcher
+    // (issue #573) each post a single deterministic final-status comment
+    // with cost/turns/duration. Email remains a log-only stub until SES
+    // wires.
     new FanOutConsumer(this, 'FanOutConsumer', {
       taskEventsTable: taskEventsTable.table,
       taskTable: taskTable.table,
@@ -941,6 +942,18 @@ export class AgentStack extends Stack {
         service: 'secretsmanager',
         resource: 'secret',
         resourceName: 'bgagent-linear-oauth-*',
+        arnFormat: ArnFormat.COLON_RESOURCE_NAME,
+      }),
+      // Jira dispatcher (issue #573) posts a deterministic final-status
+      // comment with cost/turns/duration on Jira-origin terminal tasks.
+      // Same scope `bgagent-jira-oauth-*` as the orchestrator and Jira
+      // webhook processor — Lambdas in this stack share the rotated-token
+      // write path.
+      jiraWorkspaceRegistryTable: jiraIntegration.workspaceRegistryTable,
+      jiraOauthSecretArnPattern: Stack.of(this).formatArn({
+        service: 'secretsmanager',
+        resource: 'secret',
+        resourceName: 'bgagent-jira-oauth-*',
         arnFormat: ArnFormat.COLON_RESOURCE_NAME,
       }),
     });

--- a/cdk/test/constructs/fanout-consumer.test.ts
+++ b/cdk/test/constructs/fanout-consumer.test.ts
@@ -165,6 +165,68 @@ describe('FanOutConsumer', () => {
     });
   });
 
+  test('wires JIRA_WORKSPACE_REGISTRY_TABLE_NAME + the bgagent-jira-oauth-* grant when the Jira props are provided (#573)', () => {
+    const app = new App();
+    const stack = new Stack(app, 'TestStack');
+    const jiraRegistry = new dynamodb.Table(stack, 'JiraRegistry', {
+      partitionKey: { name: 'jira_cloud_id', type: dynamodb.AttributeType.STRING },
+    });
+    new FanOutConsumer(stack, 'FanOut', {
+      taskEventsTable: makeTaskEventsTable(stack),
+      jiraWorkspaceRegistryTable: jiraRegistry,
+      jiraOauthSecretArnPattern:
+        'arn:aws:secretsmanager:us-east-1:111122223333:secret:bgagent-jira-oauth-*',
+    });
+    const template = Template.fromStack(stack);
+
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Environment: {
+        Variables: Match.objectLike({
+          JIRA_WORKSPACE_REGISTRY_TABLE_NAME: Match.anyValue(),
+        }),
+      },
+    });
+    // The resolver rotates an expiring token in place → needs Put as well
+    // as Get, scoped to the per-tenant secret prefix (same shape as Linear).
+    template.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: ['secretsmanager:GetSecretValue', 'secretsmanager:PutSecretValue'],
+            Effect: 'Allow',
+            Resource: Match.stringLikeRegexp('bgagent-jira-oauth-\\*'),
+          }),
+        ]),
+      },
+    });
+  });
+
+  test('omits the JIRA env var + bgagent-jira-oauth-* grant when the Jira props are absent (graceful degrade)', () => {
+    const app = new App();
+    const stack = new Stack(app, 'TestStack');
+    new FanOutConsumer(stack, 'FanOut', {
+      taskEventsTable: makeTaskEventsTable(stack),
+      // intentionally no Jira props
+    });
+    const template = Template.fromStack(stack);
+
+    const fns = template.findResources('AWS::Lambda::Function');
+    for (const fn of Object.values(fns)) {
+      const vars = ((fn as { Properties?: { Environment?: { Variables?: Record<string, unknown> } } })
+        .Properties?.Environment?.Variables) ?? {};
+      expect(vars.JIRA_WORKSPACE_REGISTRY_TABLE_NAME).toBeUndefined();
+    }
+    const policies = template.findResources('AWS::IAM::Policy');
+    for (const policy of Object.values(policies)) {
+      const stmts = (policy as { Properties?: { PolicyDocument?: { Statement?: unknown[] } } })
+        .Properties?.PolicyDocument?.Statement ?? [];
+      for (const stmt of stmts) {
+        const resource = JSON.stringify((stmt as { Resource?: unknown }).Resource ?? '');
+        expect(resource.includes('bgagent-jira-oauth')).toBe(false);
+      }
+    }
+  });
+
   test('passes TASK_TABLE_NAME env var when taskTable is provided', () => {
     // The Slack dispatcher requires this env var (review #3); the
     // construct must wire it from the prop. Its absence triggers the

--- a/cdk/test/handlers/fanout-task-events.test.ts
+++ b/cdk/test/handlers/fanout-task-events.test.ts
@@ -2091,7 +2091,7 @@ describe('renderJiraFinalStatusComment', () => {
     expect(text).toContain('cost: — • turns: — • duration: —');
   });
 
-  test('✅ success path renders the PR link (diverges from Linear)', () => {
+  test('✅ success path renders the PR link (agent step-2 comment not guaranteed — ABCA-584)', () => {
     const paragraphs = renderJiraFinalStatusComment({
       eventType: 'task_completed',
       prUrl: 'https://github.com/o/r/pull/7',
@@ -2128,8 +2128,8 @@ describe('renderJiraFinalStatusComment', () => {
     expect(text).not.toContain('PR:');
   });
 
-  test('⚠️ frame renders the classifier title + PR link', () => {
-    const text = flatten(renderJiraFinalStatusComment({
+  test('⚠️ frame renders the classifier title + PR link, bolding only through the reason', () => {
+    const paragraphs = renderJiraFinalStatusComment({
       eventType: 'task_failed',
       prUrl: 'https://github.com/owner/repo/pull/35',
       costUsd: 3.44,
@@ -2138,11 +2138,37 @@ describe('renderJiraFinalStatusComment', () => {
       durationS: 1272,
       taskId: 't-abca-91',
       errorTitle: 'Hit max-turns cap',
-    }));
+    });
+    const text = flatten(paragraphs);
     expect(text).toContain('⚠️');
     expect(text).toContain('Shipped a PR but stopped early');
     expect(text).toContain('Hit max-turns cap');
     expect(text).toContain('PR: https://github.com/owner/repo/pull/35');
+    // Bold scope mirrors Linear: the reason is bold, the trailing advice is
+    // a separate un-bolded run (review comment #4).
+    expect(paragraphs[0][0]).toEqual({
+      text: '⚠️ Shipped a PR but stopped early — Hit max-turns cap',
+      strong: true,
+    });
+    expect(paragraphs[0][1]).toEqual({ text: ' — review and decide if more work is needed' });
+  });
+
+  test('❌ task_timed_out humanizes the subtype — "Task timed out", not "timed_out"', () => {
+    // Jira is the only channel routing task_timed_out through this renderer,
+    // so the multi-word subtype is a case the copied-from-Linear code never
+    // exercised (review comment #2).
+    const paragraphs = renderJiraFinalStatusComment({
+      eventType: 'task_timed_out',
+      prUrl: null,
+      costUsd: 0.1,
+      turns: 5,
+      maxTurns: 5,
+      durationS: 3600,
+      taskId: 't-timeout',
+      errorTitle: null,
+    });
+    expect(paragraphs[0][0]).toEqual({ text: '❌ Task timed out', strong: true });
+    expect(flatten(paragraphs)).not.toContain('timed_out');
   });
 
   test('❌ frame renders without a colon when errorTitle is null', () => {

--- a/cdk/test/handlers/fanout-task-events.test.ts
+++ b/cdk/test/handlers/fanout-task-events.test.ts
@@ -107,13 +107,43 @@ jest.mock('../../src/handlers/shared/linear-feedback', () => ({
   ) => mockPostIssueComment(ctx, issueId, body),
 }));
 
+// Jira dispatcher posts via `postIssueCommentAdf` in `jira-feedback.ts`
+// (#573). Mock it + `buildAdfDocument` so dispatcher tests observe the call
+// shape without exercising the real OAuth-resolver + REST path. The
+// `buildAdfDocument` stub returns the paragraph runs verbatim under `_adf`
+// so tests can flatten them back to text (see `adfText`) instead of walking
+// real ADF nodes. Default ``{ ok: true }`` drives the happy path.
+const mockPostIssueCommentAdf: jest.Mock = jest.fn().mockResolvedValue({ ok: true });
+const mockBuildAdfDocument: jest.Mock = jest.fn(
+  (paragraphs: ReadonlyArray<ReadonlyArray<{ text: string }>>) => ({ _adf: paragraphs }),
+);
+jest.mock('../../src/handlers/shared/jira-feedback', () => ({
+  postIssueCommentAdf: (
+    ctx: { cloudId: string; registryTableName: string },
+    issueKey: string,
+    body: unknown,
+  ) => mockPostIssueCommentAdf(ctx, issueKey, body),
+  buildAdfDocument: (paragraphs: ReadonlyArray<ReadonlyArray<{ text: string }>>) =>
+    mockBuildAdfDocument(paragraphs),
+}));
+
 process.env.TASK_TABLE_NAME = 'Tasks';
 process.env.GITHUB_TOKEN_SECRET_ARN = 'arn:aws:secretsmanager:us-east-1:0:secret:platform';
 process.env.LINEAR_WORKSPACE_REGISTRY_TABLE_NAME = 'LinearWorkspaceRegistry';
+process.env.JIRA_WORKSPACE_REGISTRY_TABLE_NAME = 'JiraWorkspaceRegistry';
+
+/** Flatten the stubbed ADF (`{ _adf: paragraphs }`) back to a newline-joined
+ *  string so Jira dispatcher tests can assert on rendered text the same way
+ *  the Linear tests assert on the Markdown body string. */
+function adfText(body: unknown): string {
+  const paragraphs = (body as { _adf?: ReadonlyArray<ReadonlyArray<{ text: string }>> })._adf ?? [];
+  return paragraphs.map((runs) => runs.map((r) => r.text).join('')).join('\n');
+}
 
 import {
   CHANNEL_DEFAULTS,
   parseStreamRecord,
+  renderJiraFinalStatusComment,
   renderLinearFinalStatusComment,
   resolveChannelFilter,
   routeEvent,
@@ -297,6 +327,34 @@ describe('fanout-task-events: per-channel filter contract (design §6.2)', () =>
     ]);
   });
 
+  test('Linear subscribes to terminal events only (post-once final-status comment)', () => {
+    const f = CHANNEL_DEFAULTS.linear;
+    expect([...f].sort()).toEqual([
+      'task_cancelled',
+      'task_completed',
+      'task_failed',
+      'task_stranded',
+    ]);
+  });
+
+  test('Jira subscribes to terminal events + task_timed_out (post-once final-status comment, #573)', () => {
+    // Jira's post-once final-status comment. Mirrors Linear but also
+    // includes ``task_timed_out`` (a distinct terminal event the
+    // orchestrator now emits; Linear's default predates it).
+    const f = CHANNEL_DEFAULTS.jira;
+    expect([...f].sort()).toEqual([
+      'task_cancelled',
+      'task_completed',
+      'task_failed',
+      'task_stranded',
+      'task_timed_out',
+    ]);
+    // Approvals / progress milestones are excluded — Jira has no
+    // comment-edit API, so one comment per terminal event, not N.
+    expect(f.has('pr_created')).toBe(false);
+    expect(f.has('approval_requested')).toBe(false);
+  });
+
   test('agent_error routes only to Slack, not Email or GitHub', () => {
     // Operator-focused event. Email fires once per outcome; GitHub
     // edits in place on PR activity; only Slack surfaces errors
@@ -374,32 +432,40 @@ describe('fanout-task-events: routeEvent (per-channel dispatch)', () => {
     timestamp: '2026-04-22T04:00:00Z',
   });
 
-  test('task_completed routes to all four channels (slack, github, linear, email)', async () => {
-    // Linear joined the dispatcher list in #239: terminal-events fan
-    // out to a deterministic platform-side comment for Linear-origin
-    // tasks. The dispatcher itself short-circuits on
-    // ``channel_source !== 'linear'`` so non-Linear tasks see no
+  test('task_completed routes to all five channels (slack, github, linear, jira, email)', async () => {
+    // Linear joined the dispatcher list in #239 and Jira in #573:
+    // terminal-events fan out to a deterministic platform-side comment
+    // for Linear-/Jira-origin tasks. Each dispatcher short-circuits on
+    // its own ``channel_source`` gate so non-matching tasks see no
     // observable effect, but the routing layer still counts it as
     // dispatched (the same way Slack's channel_source gate doesn't
     // remove it from the dispatched list for non-Slack tasks).
     const outcome = await routeEvent(mk('task_completed'));
-    expect([...outcome.dispatched].sort()).toEqual(['email', 'github', 'linear', 'slack']);
+    expect([...outcome.dispatched].sort()).toEqual(['email', 'github', 'jira', 'linear', 'slack']);
     expect(outcome.infraRejections).toEqual([]);
   });
 
-  test('task_cancelled skips Email per §6.2 (Slack + GitHub + Linear)', async () => {
+  test('task_cancelled skips Email per §6.2 (Slack + GitHub + Linear + Jira)', async () => {
     // Regression guard against accidentally folding cancelled+stranded
     // into Email via a shared TERMINAL spread — design says Email is
     // minimal (task_completed, task_failed, approval_required only).
-    // Linear joined the terminal-event default in #239 alongside the
-    // existing Slack + GitHub.
+    // Linear joined the terminal-event default in #239 and Jira in #573
+    // alongside the existing Slack + GitHub.
     const outcome = await routeEvent(mk('task_cancelled'));
-    expect([...outcome.dispatched].sort()).toEqual(['github', 'linear', 'slack']);
+    expect([...outcome.dispatched].sort()).toEqual(['github', 'jira', 'linear', 'slack']);
   });
 
   test('task_stranded skips Email per §6.2', async () => {
     const outcome = await routeEvent(mk('task_stranded'));
-    expect([...outcome.dispatched].sort()).toEqual(['github', 'linear', 'slack']);
+    expect([...outcome.dispatched].sort()).toEqual(['github', 'jira', 'linear', 'slack']);
+  });
+
+  test('task_timed_out routes to Slack + Jira (Linear default predates it)', async () => {
+    // ``task_timed_out`` is a distinct terminal event the orchestrator
+    // emits. Slack and Email-... actually email does NOT include it; the
+    // Jira default (added in #573) does, Linear's (#239) does not.
+    const outcome = await routeEvent(mk('task_timed_out'));
+    expect([...outcome.dispatched].sort()).toEqual(['jira', 'slack']);
   });
 
   test('agent_error routes only to Slack', async () => {
@@ -424,7 +490,7 @@ describe('fanout-task-events: routeEvent (per-channel dispatch)', () => {
   test('per-task override silences one channel without affecting others', async () => {
     const overrides: TaskNotificationsConfig = { slack: { enabled: false } };
     const outcome = await routeEvent(mk('task_completed'), overrides);
-    expect([...outcome.dispatched].sort()).toEqual(['email', 'github', 'linear']);
+    expect([...outcome.dispatched].sort()).toEqual(['email', 'github', 'jira', 'linear']);
     expect(outcome.dispatched).not.toContain('slack');
   });
 });
@@ -472,12 +538,12 @@ describe('fanout-task-events: channel isolation', () => {
       expect(mockDispatchSlackEvent).toHaveBeenCalledTimes(1);
 
       // (2) Telemetry truthfulness: Slack must NOT be in ``dispatched``
-      // because its dispatcher rejected. Email + GitHub + Linear are.
-      // Linear joined the terminal-event dispatcher list in #239; for
-      // non-Linear tasks (this test omits channel_source — dispatcher
-      // short-circuits early but still resolves cleanly so it counts
-      // as dispatched).
-      expect([...outcome.dispatched].sort()).toEqual(['email', 'github', 'linear']);
+      // because its dispatcher rejected. Email + GitHub + Linear + Jira
+      // are. Linear (#239) and Jira (#573) joined the terminal-event
+      // dispatcher list; for non-Linear/non-Jira tasks (this test omits
+      // channel_source — those dispatchers short-circuit early but still
+      // resolve cleanly so they count as dispatched).
+      expect([...outcome.dispatched].sort()).toEqual(['email', 'github', 'jira', 'linear']);
       expect(outcome.dispatched).not.toContain('slack');
 
       // (3) Slack landed in ``infraRejections`` so the handler will
@@ -1760,6 +1826,363 @@ describe('renderLinearFinalStatusComment', () => {
     expect(body).toContain('❌');
     expect(body).toContain('cancelled');
     expect(body).not.toMatch(/cancelled:\s/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Jira dispatcher (issue #573) — mirrors the Linear dispatcher suite above
+// ---------------------------------------------------------------------------
+
+describe('fanout-task-events: Jira dispatcher (issue #573)', () => {
+  const TASK_RECORD_JIRA = {
+    task_id: 't-jira',
+    user_id: 'u-1',
+    status: 'COMPLETED',
+    repo: 'owner/repo',
+    branch_name: 'bgagent/t-jira/fix',
+    channel_source: 'jira',
+    channel_metadata: {
+      jira_cloud_id: 'cloud-uuid-acme',
+      jira_issue_key: 'KAN-42',
+    },
+    status_created_at: 'COMPLETED#2026-06-30T12:00:00Z',
+    created_at: '2026-06-30T11:50:00Z',
+    updated_at: '2026-06-30T12:00:00Z',
+    cost_usd: 0.55,
+    turns_attempted: 27,
+    max_turns: 100,
+    duration_s: 221,
+    pr_url: 'https://github.com/owner/repo/pull/13',
+  };
+
+  beforeEach(() => {
+    mockDdbSend.mockReset().mockResolvedValue({ Item: undefined });
+    mockPostIssueCommentAdf.mockReset().mockResolvedValue({ ok: true });
+    mockBuildAdfDocument.mockClear();
+    // Keep the sibling dispatchers quiet so they don't reject the batch.
+    mockDispatchSlackEvent.mockReset().mockResolvedValue(undefined);
+    mockUpsertTaskComment.mockReset().mockResolvedValue({ commentId: 1, created: false });
+    mockRenderCommentBody.mockReset().mockReturnValue('rendered body');
+    mockLoadRepoConfig.mockReset().mockResolvedValue(null);
+    mockResolveGitHubToken.mockReset().mockResolvedValue('ghp_fake');
+    mockPostIssueComment.mockReset().mockResolvedValue({ ok: true });
+  });
+
+  const mockGet = (item: unknown) => {
+    mockDdbSend.mockReset().mockImplementation((cmd: { _type?: string }) => {
+      if (cmd?._type === 'Get') return Promise.resolve({ Item: item });
+      return Promise.resolve({});
+    });
+  };
+
+  test('task_completed posts ✅ comment with cost / turns / duration + PR link on the Jira issue', async () => {
+    mockGet(TASK_RECORD_JIRA);
+
+    const event: DynamoDBStreamEvent = { Records: [mkEvent('task_completed', 't-jira')] };
+    await handler(event);
+
+    expect(mockPostIssueCommentAdf).toHaveBeenCalledTimes(1);
+    const [ctx, issueKey, body] = mockPostIssueCommentAdf.mock.calls[0];
+    expect(ctx).toEqual({ cloudId: 'cloud-uuid-acme', registryTableName: 'JiraWorkspaceRegistry' });
+    expect(issueKey).toBe('KAN-42');
+    const text = adfText(body);
+    expect(text).toContain('✅');
+    expect(text).toContain('Task completed');
+    expect(text).toContain('$0.55');
+    expect(text).toContain('27 / 100');
+    expect(text).toContain('3m 41s');
+    // Unlike Linear, the PR URL IS rendered on the ✅ success path — the
+    // agent-side terminal comment (which carried it) was demoted to this
+    // dispatcher, so this is Jira's only surviving PR-link surface (#573).
+    expect(text).toContain('https://github.com/owner/repo/pull/13');
+    expect(text).toContain('t-jira');
+  });
+
+  test('task_failed without PR renders ❌ frame', async () => {
+    mockGet({ ...TASK_RECORD_JIRA, pr_url: undefined, error_message: 'Generic crash' });
+
+    const event: DynamoDBStreamEvent = { Records: [mkEvent('task_failed', 't-jira')] };
+    await handler(event);
+
+    const [, , body] = mockPostIssueCommentAdf.mock.calls[0];
+    const text = adfText(body);
+    expect(text).toContain('❌');
+    expect(text).not.toContain('Shipped a PR');
+  });
+
+  test('error_max_turns + pr_url renders ⚠️ "shipped a PR but stopped early" frame', async () => {
+    mockGet({
+      ...TASK_RECORD_JIRA,
+      error_message: 'Task did not succeed: agent_status="error_max_turns"',
+      turns_attempted: 101,
+      cost_usd: 3.44,
+      duration_s: 1272,
+    });
+
+    const event: DynamoDBStreamEvent = { Records: [mkEvent('task_failed', 't-jira')] };
+    await handler(event);
+
+    const [, , body] = mockPostIssueCommentAdf.mock.calls[0];
+    const text = adfText(body);
+    expect(text).toContain('⚠️');
+    expect(text).toContain('Shipped a PR but stopped early');
+    expect(text).toContain('https://github.com/owner/repo/pull/13');
+    expect(text).toContain('$3.44');
+    expect(text).toContain('101 / 100');
+    expect(text).toContain('21m 12s');
+  });
+
+  test('task_timed_out posts a Jira comment (Jira default subscribes to it)', async () => {
+    mockGet({ ...TASK_RECORD_JIRA, error_message: 'Task did not succeed: timed out', pr_url: undefined });
+
+    const event: DynamoDBStreamEvent = { Records: [mkEvent('task_timed_out', 't-jira')] };
+    await handler(event);
+
+    expect(mockPostIssueCommentAdf).toHaveBeenCalledTimes(1);
+    const [, , body] = mockPostIssueCommentAdf.mock.calls[0];
+    expect(adfText(body)).toContain('❌');
+  });
+
+  test('non-Jira task short-circuits — postIssueCommentAdf never called', async () => {
+    mockGet({ ...TASK_RECORD_JIRA, channel_source: 'github' });
+
+    const event: DynamoDBStreamEvent = { Records: [mkEvent('task_completed', 't-jira')] };
+    await handler(event);
+
+    expect(mockPostIssueCommentAdf).not.toHaveBeenCalled();
+  });
+
+  test('Jira-origin task missing jira_issue_key — skip without posting', async () => {
+    mockGet({ ...TASK_RECORD_JIRA, channel_metadata: { jira_cloud_id: 'cloud-uuid-acme' } });
+
+    const event: DynamoDBStreamEvent = { Records: [mkEvent('task_completed', 't-jira')] };
+    await handler(event);
+
+    expect(mockPostIssueCommentAdf).not.toHaveBeenCalled();
+  });
+
+  test('terminal post failure (auth, bad issue key) does not reject the dispatcher', async () => {
+    mockGet(TASK_RECORD_JIRA);
+    mockPostIssueCommentAdf.mockReset().mockResolvedValue({ ok: false, retryable: false });
+
+    const event: DynamoDBStreamEvent = { Records: [mkEvent('task_completed', 't-jira')] };
+    const result = await handler(event);
+
+    expect(mockPostIssueCommentAdf).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ batchItemFailures: [] });
+  });
+
+  test('retryable post failure (network, 5xx, 429) escalates to batchItemFailures', async () => {
+    mockGet(TASK_RECORD_JIRA);
+    mockPostIssueCommentAdf.mockReset().mockResolvedValue({ ok: false, retryable: true });
+
+    const records = [mkEvent('task_completed', 't-jira')];
+    const event: DynamoDBStreamEvent = { Records: records };
+    const result = await handler(event);
+
+    expect(mockPostIssueCommentAdf).toHaveBeenCalledTimes(1);
+    expect(result.batchItemFailures).toHaveLength(1);
+    expect(result.batchItemFailures[0]).toEqual({ itemIdentifier: records[0].eventID });
+
+    // No marker write — the retry must be allowed to post.
+    const updates = mockDdbSend.mock.calls
+      .map(([cmd]) => cmd as { _type?: string; input?: { UpdateExpression?: string } })
+      .filter((cmd) => cmd?._type === 'Update'
+        && cmd.input?.UpdateExpression?.includes('jira_final_comment_event_id'));
+    expect(updates).toHaveLength(0);
+  });
+
+  test('successful post persists the post-once marker on the TaskRecord', async () => {
+    mockGet(TASK_RECORD_JIRA);
+
+    const event: DynamoDBStreamEvent = { Records: [mkEvent('task_completed', 't-jira')] };
+    await handler(event);
+
+    const updates = mockDdbSend.mock.calls
+      .map(([cmd]) => cmd as { _type?: string; input?: { UpdateExpression?: string } })
+      .filter((cmd) => cmd?._type === 'Update'
+        && cmd.input?.UpdateExpression?.includes('jira_final_comment_event_id'));
+    expect(updates).toHaveLength(1);
+  });
+
+  test('marker already on the TaskRecord → retry skips the duplicate post (idempotency)', async () => {
+    mockGet({ ...TASK_RECORD_JIRA, jira_final_comment_event_id: 'EVT001' });
+
+    const event: DynamoDBStreamEvent = { Records: [mkEvent('task_completed', 't-jira')] };
+    const result = await handler(event);
+
+    expect(mockPostIssueCommentAdf).not.toHaveBeenCalled();
+    expect(result).toEqual({ batchItemFailures: [] });
+  });
+
+  test('failed post does not persist the marker (next retry may post)', async () => {
+    mockGet(TASK_RECORD_JIRA);
+    mockPostIssueCommentAdf.mockReset().mockResolvedValue({ ok: false, retryable: false });
+
+    const event: DynamoDBStreamEvent = { Records: [mkEvent('task_completed', 't-jira')] };
+    await handler(event);
+
+    const updates = mockDdbSend.mock.calls
+      .map(([cmd]) => cmd as { _type?: string; input?: { UpdateExpression?: string } })
+      .filter((cmd) => cmd?._type === 'Update'
+        && cmd.input?.UpdateExpression?.includes('jira_final_comment_event_id'));
+    expect(updates).toHaveLength(0);
+  });
+
+  test('marker persist failure does not reject the dispatcher (post already succeeded)', async () => {
+    mockDdbSend.mockReset().mockImplementation((cmd: { _type?: string }) => {
+      if (cmd?._type === 'Get') return Promise.resolve({ Item: TASK_RECORD_JIRA });
+      if (cmd?._type === 'Update') return Promise.reject(new Error('DDB throttled'));
+      return Promise.resolve({});
+    });
+
+    const event: DynamoDBStreamEvent = { Records: [mkEvent('task_completed', 't-jira')] };
+    const result = await handler(event);
+
+    expect(mockPostIssueCommentAdf).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ batchItemFailures: [] });
+  });
+
+  test('JIRA_WORKSPACE_REGISTRY_TABLE_NAME unset → dispatcher logs WARN and skips', async () => {
+    const original = process.env.JIRA_WORKSPACE_REGISTRY_TABLE_NAME;
+    delete process.env.JIRA_WORKSPACE_REGISTRY_TABLE_NAME;
+    const loggerModule = await import('../../src/handlers/shared/logger');
+    const warnSpy = jest.spyOn(loggerModule.logger, 'warn').mockImplementation(() => undefined);
+    try {
+      mockGet(TASK_RECORD_JIRA);
+
+      const event: DynamoDBStreamEvent = { Records: [mkEvent('task_completed', 't-jira')] };
+      const result = await handler(event);
+
+      expect(mockPostIssueCommentAdf).not.toHaveBeenCalled();
+      expect(result).toEqual({ batchItemFailures: [] });
+      const missingEnvWarn = warnSpy.mock.calls
+        .map(c => c[1] as Record<string, unknown> | undefined)
+        .find(meta => meta?.event === 'fanout.jira.missing_env');
+      expect(missingEnvWarn).toBeDefined();
+      expect(missingEnvWarn?.error_id).toBe('FANOUT_JIRA_MISSING_ENV');
+    } finally {
+      warnSpy.mockRestore();
+      if (original !== undefined) process.env.JIRA_WORKSPACE_REGISTRY_TABLE_NAME = original;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderJiraFinalStatusComment — table-driven tests for the ADF formatter
+// ---------------------------------------------------------------------------
+
+describe('renderJiraFinalStatusComment', () => {
+  /** Flatten the renderer's ADF-paragraph output to a single string. */
+  const flatten = (paragraphs: ReadonlyArray<ReadonlyArray<{ text: string }>>) =>
+    paragraphs.map((runs) => runs.map((r) => r.text).join('')).join('\n');
+
+  test('all metrics null → renders em-dash placeholders', () => {
+    const text = flatten(renderJiraFinalStatusComment({
+      eventType: 'task_failed',
+      prUrl: null,
+      costUsd: null,
+      turns: null,
+      maxTurns: null,
+      durationS: null,
+      taskId: 't-empty',
+      errorTitle: null,
+    }));
+    expect(text).toContain('cost: — • turns: — • duration: —');
+  });
+
+  test('✅ success path renders the PR link (diverges from Linear)', () => {
+    const paragraphs = renderJiraFinalStatusComment({
+      eventType: 'task_completed',
+      prUrl: 'https://github.com/o/r/pull/7',
+      costUsd: 0.5,
+      turns: 3,
+      maxTurns: 100,
+      durationS: 60,
+      taskId: 't',
+      errorTitle: null,
+    });
+    const text = flatten(paragraphs);
+    expect(text).toContain('✅');
+    expect(text).toContain('PR: https://github.com/o/r/pull/7');
+    // The header run is bold (ADF strong mark) — the serializer maps this.
+    expect(paragraphs[0][0]).toEqual({ text: '✅ Task completed', strong: true });
+  });
+
+  test('✅ success path without a PR omits the PR line', () => {
+    const text = flatten(renderJiraFinalStatusComment({
+      eventType: 'task_completed',
+      prUrl: null,
+      costUsd: 0.5,
+      turns: 3,
+      maxTurns: 100,
+      durationS: 60,
+      taskId: 't',
+      errorTitle: null,
+    }));
+    expect(text).not.toContain('PR:');
+  });
+
+  test('⚠️ frame renders the classifier title + PR link', () => {
+    const text = flatten(renderJiraFinalStatusComment({
+      eventType: 'task_failed',
+      prUrl: 'https://github.com/owner/repo/pull/35',
+      costUsd: 3.44,
+      turns: 101,
+      maxTurns: 100,
+      durationS: 1272,
+      taskId: 't-abca-91',
+      errorTitle: 'Hit max-turns cap',
+    }));
+    expect(text).toContain('⚠️');
+    expect(text).toContain('Shipped a PR but stopped early');
+    expect(text).toContain('Hit max-turns cap');
+    expect(text).toContain('PR: https://github.com/owner/repo/pull/35');
+  });
+
+  test('❌ frame renders without a colon when errorTitle is null', () => {
+    const text = flatten(renderJiraFinalStatusComment({
+      eventType: 'task_cancelled',
+      prUrl: null,
+      costUsd: null,
+      turns: null,
+      maxTurns: null,
+      durationS: null,
+      taskId: 't',
+      errorTitle: null,
+    }));
+    expect(text).toContain('❌');
+    expect(text).toContain('cancelled');
+    expect(text).not.toMatch(/cancelled:\s/);
+  });
+
+  test('turns present but maxTurns null → renders just turns without slash', () => {
+    const text = flatten(renderJiraFinalStatusComment({
+      eventType: 'task_completed',
+      prUrl: null,
+      costUsd: 0.5,
+      turns: 27,
+      maxTurns: null,
+      durationS: 60,
+      taskId: 't',
+      errorTitle: null,
+    }));
+    expect(text).toContain('turns: 27 ');
+    expect(text).not.toContain('27 /');
+  });
+
+  test('task-id footer run is italic (ADF em mark)', () => {
+    const paragraphs = renderJiraFinalStatusComment({
+      eventType: 'task_completed',
+      prUrl: null,
+      costUsd: 0.5,
+      turns: 3,
+      maxTurns: 100,
+      durationS: 60,
+      taskId: 't-foot',
+      errorTitle: null,
+    });
+    expect(paragraphs[paragraphs.length - 1][0]).toEqual({ text: 'task t-foot', em: true });
   });
 });
 

--- a/cdk/test/handlers/fanout-task-events.test.ts
+++ b/cdk/test/handlers/fanout-task-events.test.ts
@@ -2107,6 +2107,11 @@ describe('renderJiraFinalStatusComment', () => {
     expect(text).toContain('PR: https://github.com/o/r/pull/7');
     // The header run is bold (ADF strong mark) — the serializer maps this.
     expect(paragraphs[0][0]).toEqual({ text: '✅ Task completed', strong: true });
+    // The URL run carries an href so buildAdfDocument emits a clickable
+    // link mark — a bare URL in ADF text is NOT auto-linked (issue #573
+    // follow-up). Find the run whose text is the URL and assert its href.
+    const urlRun = paragraphs.flat().find((r) => r.text === 'https://github.com/o/r/pull/7');
+    expect(urlRun).toEqual({ text: 'https://github.com/o/r/pull/7', href: 'https://github.com/o/r/pull/7' });
   });
 
   test('✅ success path without a PR omits the PR line', () => {

--- a/cdk/test/handlers/shared/jira-feedback.test.ts
+++ b/cdk/test/handlers/shared/jira-feedback.test.ts
@@ -22,7 +22,12 @@ jest.mock('../../../src/handlers/shared/jira-oauth-resolver', () => ({
   resolveJiraOauthToken: (...args: unknown[]) => resolveJiraOauthTokenMock(...args),
 }));
 
-import { postIssueComment, reportIssueFailure } from '../../../src/handlers/shared/jira-feedback';
+import {
+  buildAdfDocument,
+  postIssueComment,
+  postIssueCommentAdf,
+  reportIssueFailure,
+} from '../../../src/handlers/shared/jira-feedback';
 
 const CTX = { cloudId: 'cloud-uuid-1', registryTableName: 'JiraWorkspaceRegistry' };
 
@@ -253,5 +258,142 @@ describe('jira-feedback: 401 → forced refresh → retry (issue #370)', () => {
     // Exactly two POSTs — the retry is bounded at one attempt.
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(resolveJiraOauthTokenMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('jira-feedback: buildAdfDocument (multi-paragraph ADF, #573)', () => {
+  test('maps each paragraph to an ADF paragraph node, preserving order', () => {
+    const doc = buildAdfDocument([
+      [{ text: 'header', strong: true }],
+      [{ text: 'metrics line' }],
+      [{ text: 'task t-1', em: true }],
+    ]);
+    expect(doc.type).toBe('doc');
+    expect(doc.version).toBe(1);
+    const content = doc.content as Array<{ type: string; content: Array<Record<string, unknown>> }>;
+    expect(content).toHaveLength(3);
+    expect(content.every((p) => p.type === 'paragraph')).toBe(true);
+    expect(content[1].content[0]).toEqual({ type: 'text', text: 'metrics line' });
+  });
+
+  test('emits strong / em marks only when the run flags them', () => {
+    const doc = buildAdfDocument([[
+      { text: 'bold', strong: true },
+      { text: 'italic', em: true },
+      { text: 'both', strong: true, em: true },
+      { text: 'plain' },
+    ]]);
+    const runs = (doc.content as Array<{ content: Array<Record<string, unknown>> }>)[0].content;
+    expect(runs[0]).toEqual({ type: 'text', text: 'bold', marks: [{ type: 'strong' }] });
+    expect(runs[1]).toEqual({ type: 'text', text: 'italic', marks: [{ type: 'em' }] });
+    expect(runs[2]).toEqual({ type: 'text', text: 'both', marks: [{ type: 'strong' }, { type: 'em' }] });
+    // A plain run carries no marks key at all.
+    expect(runs[3]).toEqual({ type: 'text', text: 'plain' });
+  });
+
+  test('an empty run list yields an empty paragraph (blank-line spacing)', () => {
+    const doc = buildAdfDocument([[]]);
+    const content = doc.content as Array<{ type: string; content: unknown[] }>;
+    expect(content[0]).toEqual({ type: 'paragraph', content: [] });
+  });
+});
+
+describe('jira-feedback: postIssueCommentAdf (classified result, #573)', () => {
+  const ADF = { type: 'doc', version: 1, content: [] };
+
+  test('returns { ok: true } on 201 and posts the supplied ADF document verbatim', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(mockResponse(201));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await postIssueCommentAdf(CTX, 'ENG-42', ADF);
+
+    expect(result).toEqual({ ok: true });
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(JSON.parse(init.body as string)).toEqual({ body: ADF });
+  });
+
+  test('classifies 5xx as retryable', async () => {
+    global.fetch = jest.fn().mockResolvedValue(mockResponse(503)) as unknown as typeof fetch;
+    const result = await postIssueCommentAdf(CTX, 'ENG-42', ADF);
+    expect(result).toEqual({ ok: false, retryable: true });
+  });
+
+  test('classifies 429 as retryable', async () => {
+    global.fetch = jest.fn().mockResolvedValue(mockResponse(429)) as unknown as typeof fetch;
+    const result = await postIssueCommentAdf(CTX, 'ENG-42', ADF);
+    expect(result).toEqual({ ok: false, retryable: true });
+  });
+
+  test('classifies a 400 as terminal (non-retryable)', async () => {
+    global.fetch = jest.fn().mockResolvedValue(mockResponse(400)) as unknown as typeof fetch;
+    const result = await postIssueCommentAdf(CTX, 'ENG-42', ADF);
+    expect(result).toEqual({ ok: false, retryable: false });
+  });
+
+  test('classifies a network rejection as retryable', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('ECONNRESET')) as unknown as typeof fetch;
+    const result = await postIssueCommentAdf(CTX, 'ENG-42', ADF);
+    expect(result).toEqual({ ok: false, retryable: true });
+  });
+
+  test('token resolution failure is terminal (never retryable)', async () => {
+    resolveJiraOauthTokenMock.mockReset().mockResolvedValueOnce(null);
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await postIssueCommentAdf(CTX, 'ENG-42', ADF);
+
+    expect(result).toEqual({ ok: false, retryable: false });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test('401 → forced refresh → retry succeeds returns { ok: true }', async () => {
+    resolveJiraOauthTokenMock
+      .mockReset()
+      .mockResolvedValueOnce({ accessToken: 'stale', scope: '', siteUrl: '', oauthSecretArn: 'x' })
+      .mockResolvedValueOnce({ accessToken: 'fresh', scope: '', siteUrl: '', oauthSecretArn: 'x' });
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(mockResponse(401))
+      .mockResolvedValueOnce(mockResponse(201));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await postIssueCommentAdf(CTX, 'ENG-42', ADF);
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('a second auth rejection after refresh is terminal', async () => {
+    resolveJiraOauthTokenMock
+      .mockReset()
+      .mockResolvedValueOnce({ accessToken: 'stale', scope: '', siteUrl: '', oauthSecretArn: 'x' })
+      .mockResolvedValueOnce({ accessToken: 'fresh', scope: '', siteUrl: '', oauthSecretArn: 'x' });
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(mockResponse(401))
+      .mockResolvedValueOnce(mockResponse(403));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await postIssueCommentAdf(CTX, 'ENG-42', ADF);
+
+    expect(result).toEqual({ ok: false, retryable: false });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('a transient error on the post-refresh retry stays retryable', async () => {
+    resolveJiraOauthTokenMock
+      .mockReset()
+      .mockResolvedValueOnce({ accessToken: 'stale', scope: '', siteUrl: '', oauthSecretArn: 'x' })
+      .mockResolvedValueOnce({ accessToken: 'fresh', scope: '', siteUrl: '', oauthSecretArn: 'x' });
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(mockResponse(401))
+      .mockResolvedValueOnce(mockResponse(500));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await postIssueCommentAdf(CTX, 'ENG-42', ADF);
+
+    expect(result).toEqual({ ok: false, retryable: true });
   });
 });

--- a/cdk/test/handlers/shared/jira-feedback.test.ts
+++ b/cdk/test/handlers/shared/jira-feedback.test.ts
@@ -296,6 +296,32 @@ describe('jira-feedback: buildAdfDocument (multi-paragraph ADF, #573)', () => {
     const content = doc.content as Array<{ type: string; content: unknown[] }>;
     expect(content[0]).toEqual({ type: 'paragraph', content: [] });
   });
+
+  test('an href run emits an ADF link mark (bare URLs are not auto-linked)', () => {
+    const doc = buildAdfDocument([[
+      { text: 'PR: ' },
+      { text: 'https://github.com/o/r/pull/7', href: 'https://github.com/o/r/pull/7' },
+    ]]);
+    const runs = (doc.content as Array<{ content: Array<Record<string, unknown>> }>)[0].content;
+    expect(runs[0]).toEqual({ type: 'text', text: 'PR: ' });
+    expect(runs[1]).toEqual({
+      type: 'text',
+      text: 'https://github.com/o/r/pull/7',
+      marks: [{ type: 'link', attrs: { href: 'https://github.com/o/r/pull/7' } }],
+    });
+  });
+
+  test('href composes with strong/em marks on the same run', () => {
+    const doc = buildAdfDocument([[
+      { text: 'link', strong: true, href: 'https://x.example/pull/1' },
+    ]]);
+    const runs = (doc.content as Array<{ content: Array<Record<string, unknown>> }>)[0].content;
+    expect(runs[0]).toEqual({
+      type: 'text',
+      text: 'link',
+      marks: [{ type: 'strong' }, { type: 'link', attrs: { href: 'https://x.example/pull/1' } }],
+    });
+  });
 });
 
 describe('jira-feedback: postIssueCommentAdf (classified result, #573)', () => {

--- a/docs/guides/JIRA_SETUP_GUIDE.md
+++ b/docs/guides/JIRA_SETUP_GUIDE.md
@@ -1,6 +1,6 @@
 # Jira integration setup guide
 
-Set up the ABCA Jira Cloud integration so that adding a label to a Jira issue triggers an autonomous task. The agent posts progress comments back on the issue as it works.
+Set up the ABCA Jira Cloud integration so that adding a label to a Jira issue triggers an autonomous task. ABCA posts progress comments back on the issue as it works — a "started" comment from the agent and a final status comment (with cost, turns, and duration) from the platform when the task finishes.
 
 ## Prerequisites
 
@@ -13,7 +13,7 @@ Set up the ABCA Jira Cloud integration so that adding a label to a Jira issue tr
 
 ## How it works
 
-A Jira-site admin creates an Atlassian OAuth 2.0 (3LO) app and authorizes it on the site. The OAuth token bundle is stored in a per-tenant Secrets Manager secret (`bgagent-jira-oauth-<cloudId>`). When a user adds the trigger label to a Jira issue, Jira fires a webhook to ABCA; the receiver verifies the `X-Hub-Signature` HMAC, dedupes, and async-invokes the processor, which resolves the tenant, looks up the project→repo mapping, and creates a task. Jira-triggered tasks always run the `coding/new-task-v1` workflow (the processor pins `workflow_ref` explicitly, since a label-triggered task always targets a mapped repo). The agent clones the repo, opens a PR, and comments on the Jira issue via the Jira REST v3 API (using the same stored OAuth token).
+A Jira-site admin creates an Atlassian OAuth 2.0 (3LO) app and authorizes it on the site. The OAuth token bundle is stored in a per-tenant Secrets Manager secret (`bgagent-jira-oauth-<cloudId>`). When a user adds the trigger label to a Jira issue, Jira fires a webhook to ABCA; the receiver verifies the `X-Hub-Signature` HMAC, dedupes, and async-invokes the processor, which resolves the tenant, looks up the project→repo mapping, and creates a task. Jira-triggered tasks always run the `coding/new-task-v1` workflow (the processor pins `workflow_ref` explicitly, since a label-triggered task always targets a mapped repo). The agent clones the repo, opens a PR, and posts a "started" comment on the Jira issue via the Jira REST v3 API (using the same stored OAuth token). When the task reaches a terminal state, the platform's fan-out plane posts a single final status comment — outcome, cost, turns, duration, and PR link — via the same REST v3 endpoint (see [How it works](#how-it-works) below).
 
 **Tenant key.** Everything is indexed on `cloudId` — the Atlassian tenant UUID, *not* the site domain or name. Webhook payloads and the OAuth flow both surface `cloudId`; it is the join key across the project-mapping, user-mapping, and workspace-registry tables.
 
@@ -34,13 +34,36 @@ Outbound (Agent → Jira) — REST v3:
 runner picks task with channel_source="jira"
   → jira_reactions resolves the OAuth access token from
     bgagent-jira-oauth-<cloudId> (JIRA_API_TOKEN)
-  → agent posts a "started" comment, then a terminal "succeeded /
-    failed (+ PR link)" comment, via
+  → agent posts a "started" comment via
     POST api.atlassian.com/ex/jira/{cloudId}/rest/api/3/issue/{key}/comment
 ```
 
+Outbound terminal status (Platform → Jira) — REST v3, deterministic:
+
+```
+task reaches a terminal event (completed / failed / cancelled /
+  stranded / timed out) → TaskEventsTable DynamoDB Stream → fan-out
+  Lambda's dispatchToJira resolves the OAuth token and posts ONE
+  final-status comment with cost, turns, duration, task id, and the
+  PR link, via the same REST v3 comment endpoint
+```
+
+The **start** comment is posted by the agent. The **terminal** comment is
+posted by the platform's fan-out plane, not the agent — so it always includes
+cost / turns / duration and fires even when the agent crashes before
+completing (max-turns, OOM). The final comment frames three outcomes:
+
+- ✅ **Task completed** — with the PR link when one was opened.
+- ⚠️ **Shipped a PR but stopped early** — the PR link plus the reason it
+  stopped (e.g. "Hit max-turns cap"), so you can review and decide.
+- ❌ **Task failed / cancelled / timed out** — with a short classifier reason.
+
 Comments are advisory and best-effort: network/auth failures are logged and
-swallowed (with an auth circuit-breaker), never gating the pipeline.
+swallowed (the agent path has an auth circuit-breaker; the platform path
+classifies transient failures as retryable and retries the record), never
+gating the task itself. Jira has no comment-edit API, so the terminal comment
+is posted exactly once (a per-task marker guards against duplicate posts on
+stream retries).
 
 > **Why REST, not the Atlassian Remote MCP?** The hosted MCP
 > (`mcp.atlassian.com`) requires an interactive, browser-based OAuth 2.1 flow
@@ -52,7 +75,7 @@ swallowed (with an auth circuit-breaker), never gating the pipeline.
 > it is expected to fail to connect today and the outbound path does not
 > depend on it.
 
-There is no DynamoDB Streams consumer and no outbound-notify Lambda — this is an inbound-only adapter, matching Linear.
+Inbound admission (webhook → task) is Jira-specific and has no DynamoDB Streams consumer of its own. The **terminal** status comment, however, is delivered by the shared fan-out plane's DynamoDB Streams consumer (`dispatchToJira`) — the same platform-side surface that posts Linear final-status comments — so it behaves identically to Linear for terminal outcomes.
 
 ## Setup walkthrough
 

--- a/docs/src/content/docs/using/Jira-setup-guide.md
+++ b/docs/src/content/docs/using/Jira-setup-guide.md
@@ -4,7 +4,7 @@ title: Jira setup guide
 
 # Jira integration setup guide
 
-Set up the ABCA Jira Cloud integration so that adding a label to a Jira issue triggers an autonomous task. The agent posts progress comments back on the issue as it works.
+Set up the ABCA Jira Cloud integration so that adding a label to a Jira issue triggers an autonomous task. ABCA posts progress comments back on the issue as it works — a "started" comment from the agent and a final status comment (with cost, turns, and duration) from the platform when the task finishes.
 
 ## Prerequisites
 
@@ -17,7 +17,7 @@ Set up the ABCA Jira Cloud integration so that adding a label to a Jira issue tr
 
 ## How it works
 
-A Jira-site admin creates an Atlassian OAuth 2.0 (3LO) app and authorizes it on the site. The OAuth token bundle is stored in a per-tenant Secrets Manager secret (`bgagent-jira-oauth-<cloudId>`). When a user adds the trigger label to a Jira issue, Jira fires a webhook to ABCA; the receiver verifies the `X-Hub-Signature` HMAC, dedupes, and async-invokes the processor, which resolves the tenant, looks up the project→repo mapping, and creates a task. Jira-triggered tasks always run the `coding/new-task-v1` workflow (the processor pins `workflow_ref` explicitly, since a label-triggered task always targets a mapped repo). The agent clones the repo, opens a PR, and comments on the Jira issue via the Jira REST v3 API (using the same stored OAuth token).
+A Jira-site admin creates an Atlassian OAuth 2.0 (3LO) app and authorizes it on the site. The OAuth token bundle is stored in a per-tenant Secrets Manager secret (`bgagent-jira-oauth-<cloudId>`). When a user adds the trigger label to a Jira issue, Jira fires a webhook to ABCA; the receiver verifies the `X-Hub-Signature` HMAC, dedupes, and async-invokes the processor, which resolves the tenant, looks up the project→repo mapping, and creates a task. Jira-triggered tasks always run the `coding/new-task-v1` workflow (the processor pins `workflow_ref` explicitly, since a label-triggered task always targets a mapped repo). The agent clones the repo, opens a PR, and posts a "started" comment on the Jira issue via the Jira REST v3 API (using the same stored OAuth token). When the task reaches a terminal state, the platform's fan-out plane posts a single final status comment — outcome, cost, turns, duration, and PR link — via the same REST v3 endpoint (see [How it works](#how-it-works) below).
 
 **Tenant key.** Everything is indexed on `cloudId` — the Atlassian tenant UUID, *not* the site domain or name. Webhook payloads and the OAuth flow both surface `cloudId`; it is the join key across the project-mapping, user-mapping, and workspace-registry tables.
 
@@ -38,13 +38,36 @@ Outbound (Agent → Jira) — REST v3:
 runner picks task with channel_source="jira"
   → jira_reactions resolves the OAuth access token from
     bgagent-jira-oauth-<cloudId> (JIRA_API_TOKEN)
-  → agent posts a "started" comment, then a terminal "succeeded /
-    failed (+ PR link)" comment, via
+  → agent posts a "started" comment via
     POST api.atlassian.com/ex/jira/{cloudId}/rest/api/3/issue/{key}/comment
 ```
 
+Outbound terminal status (Platform → Jira) — REST v3, deterministic:
+
+```
+task reaches a terminal event (completed / failed / cancelled /
+  stranded / timed out) → TaskEventsTable DynamoDB Stream → fan-out
+  Lambda's dispatchToJira resolves the OAuth token and posts ONE
+  final-status comment with cost, turns, duration, task id, and the
+  PR link, via the same REST v3 comment endpoint
+```
+
+The **start** comment is posted by the agent. The **terminal** comment is
+posted by the platform's fan-out plane, not the agent — so it always includes
+cost / turns / duration and fires even when the agent crashes before
+completing (max-turns, OOM). The final comment frames three outcomes:
+
+- ✅ **Task completed** — with the PR link when one was opened.
+- ⚠️ **Shipped a PR but stopped early** — the PR link plus the reason it
+  stopped (e.g. "Hit max-turns cap"), so you can review and decide.
+- ❌ **Task failed / cancelled / timed out** — with a short classifier reason.
+
 Comments are advisory and best-effort: network/auth failures are logged and
-swallowed (with an auth circuit-breaker), never gating the pipeline.
+swallowed (the agent path has an auth circuit-breaker; the platform path
+classifies transient failures as retryable and retries the record), never
+gating the task itself. Jira has no comment-edit API, so the terminal comment
+is posted exactly once (a per-task marker guards against duplicate posts on
+stream retries).
 
 > **Why REST, not the Atlassian Remote MCP?** The hosted MCP
 > (`mcp.atlassian.com`) requires an interactive, browser-based OAuth 2.1 flow
@@ -56,7 +79,7 @@ swallowed (with an auth circuit-breaker), never gating the pipeline.
 > it is expected to fail to connect today and the outbound path does not
 > depend on it.
 
-There is no DynamoDB Streams consumer and no outbound-notify Lambda — this is an inbound-only adapter, matching Linear.
+Inbound admission (webhook → task) is Jira-specific and has no DynamoDB Streams consumer of its own. The **terminal** status comment, however, is delivered by the shared fan-out plane's DynamoDB Streams consumer (`dispatchToJira`) — the same platform-side surface that posts Linear final-status comments — so it behaves identically to Linear for terminal outcomes.
 
 ## Setup walkthrough
 


### PR DESCRIPTION
## Summary

Closes #573 (part of the Jira-adapter parity work in #580, Phase 1).

Jira-origin tasks now get the same terminal status visibility Linear-origin tasks get today: a **deterministic, platform-side** final comment with outcome, cost, turns, duration, task id, and PR link — posted by the fan-out plane (`dispatchToJira`), not the agent. This fires even when the agent crashes before reaching its own final-comment path (max-turns, OOM), which the previous agent-side `jira_reactions.py` terminal comment could not.

## What changed

**Fan-out (`cdk/src/handlers/fanout-task-events.ts`)**
- New `jira` `NotificationChannel` + `CHANNEL_DEFAULTS` entry (terminal events + `task_timed_out`).
- New `dispatchToJira`, structurally mirroring `dispatchToLinear`: env guard → load task → `channel_source === 'jira'` gate → read `jira_cloud_id`/`jira_issue_key` from `channel_metadata` → post-once marker check → post → persist marker. Retryable failures escalate to the partial-batch retry path; terminal failures log-and-resolve.
- New `renderJiraFinalStatusComment` — same three-outcome framing as Linear (✅ completed / ⚠️ shipped-a-PR-but-stopped-early / ❌ failed), emitting ADF paragraphs. The PR link renders on the ✅ success path too, since demoting the agent-side terminal comment removes Jira's only other PR-link surface.

**Jira feedback (`cdk/src/handlers/shared/jira-feedback.ts`)**
- `buildAdfDocument` — multi-paragraph ADF with `strong`/`em` marks.
- `postIssueCommentAdf` — returns a classified `JiraPostResult` (`retryable` vs terminal), reusing the existing 401/403 forced-refresh-and-retry-once path. The boolean `postIssueComment` is unchanged for existing callers.

**Types / construct / stack**
- `TaskRecord.jira_final_comment_event_id` post-once marker (Jira analogue of `linear_final_comment_event_id`); `TaskNotificationsConfig` gains a `jira` channel.
- `FanOutConsumer` wires `JiraWorkspaceRegistryTable` + `bgagent-jira-oauth-*` Get/Put grant (guarded — a deployment without Jira onboarding gets no dangling grant).

**Agent (demotion)**
- Removed `comment_task_finished` and its two `pipeline.py` call sites so the fan-out plane owns the terminal comment (no double-post). The start comment (`comment_task_started`) stays for in-flight progress.

**Docs**
- `JIRA_SETUP_GUIDE.md` updated to describe the platform-side final comment (+ regenerated Starlight mirror).

## Acceptance criteria
- [x] Jira-origin terminal tasks receive one final comment with cost, turns, duration, task id, and the appropriate outcome.
- [x] A PR-but-stopped task includes both the PR link and the stop reason.
- [x] Agent crash before `jira_reactions.py` still produces the platform-side comment.
- [x] Retryable Jira failures → stream retry; terminal auth/config failures log-and-resolve without blocking sibling channels.
- [x] Non-Jira tasks unaffected; no duplicate terminal comments.

## Tests
- Fanout Jira: success, failure, shipped-but-stopped, `task_timed_out`, missing metadata, non-Jira skip, idempotent retry, retryable escalation, marker persistence/failure, missing-env WARN.
- `jira-feedback`: `buildAdfDocument` (marks + blank-line paragraphs), `postIssueCommentAdf` classification (201/5xx/429/4xx/network/token-fail/refresh paths).
- Construct: Jira env var + grant present when props set, absent otherwise.
- Agent: `comment_task_finished`-is-gone guard.

Full `mise run build` (agent quality, cdk compile+eslint+jest+synth, docs build) is green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)