### PR TITLE
feat(jira): transition originating issue across workflow as tasks progress (#572)

### DIFF
--- a/agent/src/jira_reactions.py
+++ b/agent/src/jira_reactions.py
@@ -236,27 +236,58 @@ def comment_task_started(
 # must never fail, block, or retry the task.
 
 #: Jira ``statusCategory.key`` for the "In Progress" band. The start transition
-#: prefers a destination in this category so standard workflows work with no
-#: per-project config. (Categories: ``new`` = To Do, ``indeterminate`` = In
-#: Progress, ``done`` = Done — the only three, and they are stable API values.)
+#: falls back to this category so standard workflows work with no per-project
+#: config. (Categories: ``new`` = To Do, ``indeterminate`` = In Progress,
+#: ``done`` = Done — the only three, and they are stable API values.)
 _IN_PROGRESS_CATEGORY = "indeterminate"
 
-#: Default destination-name match for the PR-opened transition when no override
-#: is configured. Compared case-insensitively against ``to.name``.
-_DEFAULT_REVIEW_STATUS = "in review"
+#: Ordinal rank of the three status categories, low → high. Used to skip a
+#: transition that would move the card *backward* (e.g. a re-triggered task on
+#: an issue that's already In Review must not drag it back to In Progress).
+_CATEGORY_RANK = {"new": 0, "indeterminate": 1, "done": 2}
+
+#: Preferred destination *name* for the start transition (matched
+#: case-insensitively before the category fallback). Both ``In Progress`` and
+#: ``Blocked`` share the ``indeterminate`` category, so a name match is what
+#: keeps a category-only heuristic from landing on ``Blocked`` (#605).
+_START_STATUS_NAME = "in progress"
+
+#: Preferred destination names for the PR-opened transition, tried in order.
+#: Mirrors Linear's "In Review → In Progress" fallback while also matching
+#: common review-column names, so a "Code Review" column isn't silently skipped
+#: and a stock board (no review status) still advances to / stays at In Progress
+#: rather than no-opping (#605). Ends with In Progress as the safe fallback.
+_REVIEW_STATUS_NAMES = (
+    "in review",
+    "code review",
+    "review",
+    "peer review",
+    "reviewing",
+    _START_STATUS_NAME,
+)
+
+#: Destination names the category fallback must never auto-pick. ``Blocked``
+#: shares the ``indeterminate`` category with ``In Progress``; a bare
+#: first-indeterminate heuristic could land there (#605), which is never what
+#: "move to In Progress" means. A configured override can still target it.
+_CATEGORY_FALLBACK_DENY = ("blocked",)
 
 
-def _get_transitions(cloud_id: str, issue_key: str, token: str) -> list[dict[str, Any]] | None:
-    """GET the transitions valid from the issue's current status.
+def _get_issue_transitions(
+    cloud_id: str, issue_key: str, token: str
+) -> tuple[dict[str, Any], list[dict[str, Any]]] | None:
+    """GET the issue's current status + the transitions valid from it.
 
-    Returns the ``transitions`` list (possibly empty) on success, or ``None``
-    on any failure. An empty list is normal — Jira returns one when the OAuth
-    user lacks the *Transition Issues* permission — and callers treat it as
-    "nothing to do", not an error.
+    Fetches ``?fields=status&expand=transitions`` so a single call yields both
+    the current ``status`` (to skip moving a card backward, #605) and the
+    ``transitions`` list. Returns ``(current_status, transitions)`` on success,
+    or ``None`` on any failure. An empty transitions list is normal — Jira
+    returns one when the OAuth user lacks the *Transition Issues* permission —
+    and callers treat it as "nothing to do", not an error.
     """
     url = (
         f"{JIRA_API_BASE}/{quote(cloud_id, safe='')}"
-        f"/rest/api/3/issue/{quote(issue_key, safe='')}/transitions"
+        f"/rest/api/3/issue/{quote(issue_key, safe='')}?fields=status&expand=transitions"
     )
     try:
         resp = requests.get(
@@ -268,7 +299,7 @@ def _get_transitions(cloud_id: str, issue_key: str, token: str) -> list[dict[str
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
     except requests.RequestException as e:
-        log("WARN", f"jira_reactions: transitions GET failed ({type(e).__name__}): {e}")
+        log("WARN", f"jira_reactions: issue GET failed ({type(e).__name__}): {e}")
         # nosemgrep: py-silent-success-masking -- Jira transitions are best-effort on network blips
         return None
 
@@ -276,57 +307,97 @@ def _get_transitions(cloud_id: str, issue_key: str, token: str) -> list[dict[str
         _note_auth_status(resp.status_code)
         return None
     if resp.status_code != HTTPStatus.OK:
-        log("WARN", f"jira_reactions: transitions GET HTTP {resp.status_code}: {resp.text[:200]}")
+        log("WARN", f"jira_reactions: issue GET HTTP {resp.status_code}: {resp.text[:200]}")
         return None
 
     _note_auth_status(resp.status_code)
     try:
-        transitions = resp.json().get("transitions", [])
+        payload = resp.json()
     except ValueError as e:
-        log("WARN", f"jira_reactions: transitions GET returned non-JSON: {e}")
+        log("WARN", f"jira_reactions: issue GET returned non-JSON: {e}")
         # nosemgrep: py-silent-success-masking -- Jira transitions are best-effort on bad responses
         return None
-    return transitions if isinstance(transitions, list) else []
+    # A well-formed response is a JSON object. Guard against valid-but-unexpected
+    # JSON (``null``, a bare list, a scalar) — ``.get`` would raise
+    # AttributeError, which is NOT best-effort: it propagates out of the pipeline
+    # hook and flips the task to FAILED (#605).
+    if not isinstance(payload, dict):
+        log("WARN", "jira_reactions: issue GET returned non-object JSON — skipping")
+        return None
+    current_status = (payload.get("fields") or {}).get("status") or {}
+    transitions = payload.get("transitions", [])
+    if not isinstance(current_status, dict):
+        current_status = {}
+    if not isinstance(transitions, list):
+        transitions = []
+    return current_status, transitions
+
+
+def _to_name(t: dict[str, Any]) -> str:
+    """Lowercased destination status name of a transition, or ``""``."""
+    return ((t.get("to") or {}).get("name") or "").strip().lower()
+
+
+def _to_category(t: dict[str, Any]) -> str | None:
+    """``statusCategory.key`` of a transition's destination, or ``None``."""
+    return ((t.get("to") or {}).get("statusCategory") or {}).get("key")
+
+
+def _usable(t: dict[str, Any]) -> bool:
+    """A transition we can execute unattended.
+
+    ``hasScreen`` transitions may demand required fields we can't supply, so we
+    skip them — a missing field would 400 the POST.
+    """
+    return isinstance(t, dict) and not t.get("hasScreen", False)
 
 
 def _select_transition(
     transitions: list[dict[str, Any]],
     *,
-    target_status: str | None,
-    prefer_category: str | None,
+    override: str | None,
+    prefer_names: tuple[str, ...],
+    fallback_category: str | None,
 ) -> dict[str, Any] | None:
     """Pick a transition by the resolution ladder, or ``None`` if nothing fits.
 
-    ``target_status`` (a per-project override or the ``In Review`` default) is
-    matched case-insensitively against ``to.name`` first. Only if it is unset
-    does ``prefer_category`` (a ``statusCategory.key``) act as the fallback.
-    Transitions that require a screen are skipped — filling required fields is
-    out of scope and a missing field would 400 the POST.
+    Ladder (first match wins), mirroring the Linear reference this feature is
+    modeled on (``prompt_builder.py``):
+
+    1. ``override`` — a per-project configured status name, matched
+       case-insensitively against the destination name. An override that isn't
+       reachable is a deliberate skip (no fallback — the user asked for a
+       specific status).
+    2. ``prefer_names`` — preferred destination names in priority order (e.g.
+       ``In Progress`` on start; ``In Review`` → ``Code Review`` → … on PR).
+       This is what stops a category-only heuristic from landing on ``Blocked``
+       (which shares the ``indeterminate`` category with ``In Progress``).
+    3. ``fallback_category`` — any usable transition whose destination is in
+       this ``statusCategory`` (keeps stock boards working with no config).
+
+    Screen-gated transitions are skipped throughout.
     """
+    usable = [t for t in transitions if _usable(t)]
 
-    def _usable(t: dict[str, Any]) -> bool:
-        # ``hasScreen`` transitions may demand required fields we can't supply.
-        return isinstance(t, dict) and not t.get("hasScreen", False)
+    if override:
+        wanted = override.strip().lower()
+        return next((t for t in usable if _to_name(t) == wanted), None)
 
-    if target_status:
-        wanted = target_status.strip().lower()
-        for t in transitions:
-            if not _usable(t):
-                continue
-            to_name = (t.get("to") or {}).get("name") or ""
-            if to_name.strip().lower() == wanted:
-                return t
-        # An explicit target that isn't reachable is a deliberate skip — do not
-        # silently fall back to a category heuristic the user didn't ask for.
-        return None
+    for name in prefer_names:
+        match = next((t for t in usable if _to_name(t) == name), None)
+        if match:
+            return match
 
-    if prefer_category:
-        for t in transitions:
-            if not _usable(t):
-                continue
-            category = ((t.get("to") or {}).get("statusCategory") or {}).get("key")
-            if category == prefer_category:
-                return t
+    if fallback_category:
+        return next(
+            (
+                t
+                for t in usable
+                if _to_category(t) == fallback_category
+                and _to_name(t) not in _CATEGORY_FALLBACK_DENY
+            ),
+            None,
+        )
     return None
 
 
@@ -369,15 +440,19 @@ def _transition(
     channel_metadata: dict[str, str] | None,
     *,
     lifecycle: str,
-    target_status: str | None,
-    prefer_category: str | None,
+    override: str | None,
+    prefer_names: tuple[str, ...],
+    fallback_category: str | None,
+    max_source_rank: int | None,
 ) -> None:
     """Shared best-effort transition path. No-op for non-Jira tasks.
 
-    Resolves ``(cloud_id, issue_key)``, discovers valid transitions, selects one
-    via the resolution ladder, and POSTs it. Every failure mode — disabled,
-    open circuit, missing token, empty transition list, no match, network /
-    HTTP error — is logged and swallowed so the pipeline is never affected.
+    Resolves ``(cloud_id, issue_key)``, fetches the current status + valid
+    transitions, skips if the card is already at/past the target band
+    (``max_source_rank``), selects a transition via the resolution ladder, and
+    POSTs it. Every failure mode — disabled, open circuit, missing token, empty
+    transition list, no match, network / HTTP error — is logged and swallowed
+    so the pipeline is never affected.
     """
     target = _enabled(channel_source, channel_metadata)
     if not target:
@@ -393,9 +468,29 @@ def _transition(
         log("WARN", "jira_reactions: JIRA_API_TOKEN not set; skipping transition")
         return
 
-    transitions = _get_transitions(cloud_id, issue_key, token)
+    result = _get_issue_transitions(cloud_id, issue_key, token)
+    if result is None:
+        log("WARN", f"jira_reactions: could not read issue {issue_key} — skipping {lifecycle}")
+        return
+    current_status, transitions = result
+
+    # Don't move the card backward. If the current status is already at or past
+    # the highest category this lifecycle point should advance to, skip — a
+    # re-triggered task on an already-In-Review issue must not drag it back to
+    # In Progress (mirrors Linear's "already in a later state" skip).
+    if max_source_rank is not None:
+        current_category = (current_status.get("statusCategory") or {}).get("key")
+        current_rank = _CATEGORY_RANK.get(current_category)
+        if current_rank is not None and current_rank >= max_source_rank:
+            log(
+                "TASK",
+                f"jira_reactions: {lifecycle} skip issue={issue_key} — already at "
+                f"{current_status.get('name')!r} (category {current_category!r})",
+            )
+            return
+
     if not transitions:
-        # None (error) or [] (no permission / no transitions) — both are skips.
+        # [] (no permission / no transitions) — a normal skip.
         log(
             "WARN",
             f"jira_reactions: no available transitions for {lifecycle} "
@@ -404,13 +499,17 @@ def _transition(
         return
 
     chosen = _select_transition(
-        transitions, target_status=target_status, prefer_category=prefer_category
+        transitions,
+        override=override,
+        prefer_names=prefer_names,
+        fallback_category=fallback_category,
     )
     if not chosen:
         log(
             "WARN",
             f"jira_reactions: no matching {lifecycle} transition for issue={issue_key} "
-            f"(target={target_status!r} category={prefer_category!r}) — skipping",
+            f"(override={override!r} names={prefer_names} category={fallback_category!r}) "
+            "— skipping",
         )
         return
 
@@ -428,8 +527,9 @@ def transition_task_started(
 ) -> None:
     """Move the Jira issue to an in-progress status at task start.
 
-    Uses the ``jira_status_on_start`` override when configured, else prefers a
-    transition into the ``indeterminate`` (In Progress) status category.
+    Resolution: ``jira_status_on_start`` override → a destination named
+    ``In Progress`` → any ``indeterminate``-category destination. Skips if the
+    issue is already In Progress or later (won't move a card backward).
     Best-effort; no-op for non-Jira tasks.
     """
     override = (channel_metadata or {}).get("jira_status_on_start")
@@ -437,8 +537,12 @@ def transition_task_started(
         channel_source,
         channel_metadata,
         lifecycle="start",
-        target_status=override,
-        prefer_category=None if override else _IN_PROGRESS_CATEGORY,
+        override=override,
+        prefer_names=() if override else (_START_STATUS_NAME,),
+        fallback_category=None if override else _IN_PROGRESS_CATEGORY,
+        # Skip if already In Progress (indeterminate) or Done. An override is a
+        # deliberate instruction, so honor it regardless of current status.
+        max_source_rank=None if override else _CATEGORY_RANK[_IN_PROGRESS_CATEGORY],
     )
 
 
@@ -448,18 +552,22 @@ def transition_pr_opened(
 ) -> None:
     """Move the Jira issue to a review status once a PR is opened.
 
-    Uses the ``jira_status_on_pr`` override when configured, else matches a
-    destination named ``In Review`` (case-insensitive). If neither is
-    reachable, the status is left unchanged. Best-effort; no-op for non-Jira
-    tasks.
+    Resolution: ``jira_status_on_pr`` override → a destination named
+    ``In Review`` (or a common review-column synonym) → any
+    ``indeterminate``-category destination (Linear's In Review→In Progress
+    fallback, so a stock board isn't silently skipped, #605). Skips only if the
+    issue is already Done. Best-effort; no-op for non-Jira tasks.
     """
     override = (channel_metadata or {}).get("jira_status_on_pr")
     _transition(
         channel_source,
         channel_metadata,
         lifecycle="pr_opened",
-        target_status=override or _DEFAULT_REVIEW_STATUS,
-        prefer_category=None,
+        override=override,
+        prefer_names=() if override else _REVIEW_STATUS_NAMES,
+        fallback_category=None if override else _IN_PROGRESS_CATEGORY,
+        # Only skip if already Done — moving In Progress → In Review is forward.
+        max_source_rank=None if override else _CATEGORY_RANK["done"],
     )
 
 

--- a/agent/src/jira_reactions.py
+++ b/agent/src/jira_reactions.py
@@ -1,9 +1,15 @@
-"""Jira issue-comment helper for Jira-origin tasks.
+"""Jira issue-comment and workflow-transition helpers for Jira-origin tasks.
 
 Posts a "starting" comment on the originating Jira issue at task start — the
 Jira analogue of ``linear_reactions`` (Linear uses emoji reactions; Jira's
 REST API has no lightweight reaction primitive, so comments are the right
 tool).
+
+It also moves the originating issue across its board as the task progresses
+(issue #572): To Do → In Progress on start, → In Review on PR, via the Jira
+transitions API. Like comments, transitions are best-effort — logged and
+swallowed on any failure, sharing the same auth circuit breaker — so the Jira
+board never gates the task. See the "Workflow transitions" section below.
 
 The *terminal* status comment is NOT posted from here: since issue #573 the
 deterministic fan-out plane (``cdk/src/handlers/fanout-task-events.ts``
@@ -36,6 +42,7 @@ from __future__ import annotations
 
 import os
 import threading
+from http import HTTPStatus
 from typing import Any
 from urllib.parse import quote
 
@@ -60,6 +67,47 @@ _AUTH_FAILURE_THRESHOLD = 3
 _consecutive_auth_failures: int = 0
 _auth_circuit_open: bool = False
 _auth_state_lock = threading.Lock()
+
+
+def _circuit_open() -> bool:
+    """True if the auth circuit breaker is open (short-circuit further calls)."""
+    with _auth_state_lock:
+        return _auth_circuit_open
+
+
+def _note_auth_status(status_code: int) -> None:
+    """Feed a response status into the shared 401/403 circuit breaker.
+
+    A 401/403 increments the consecutive-failure counter and opens the breaker
+    once it hits ``_AUTH_FAILURE_THRESHOLD``; any other 2xx-ish success resets
+    it. Comments and transitions share this state so a revoked token trips the
+    breaker once for all outbound Jira calls in the container.
+    """
+    global _consecutive_auth_failures, _auth_circuit_open
+
+    if status_code in (401, 403):
+        with _auth_state_lock:
+            _consecutive_auth_failures += 1
+            opened = (
+                _consecutive_auth_failures >= _AUTH_FAILURE_THRESHOLD and not _auth_circuit_open
+            )
+            if opened:
+                _auth_circuit_open = True
+                failures = _consecutive_auth_failures
+        if opened:
+            log(
+                "ERROR",
+                "jira_reactions: auth circuit OPEN after "
+                f"{failures} consecutive {status_code}s — Jira token likely "
+                "revoked/expired without a working refresh. Suppressing further "
+                "Jira calls for this container.",
+            )
+        else:
+            log("WARN", f"jira_reactions: HTTP {status_code} from Jira (auth)")
+        return
+
+    with _auth_state_lock:
+        _consecutive_auth_failures = 0
 
 
 def _enabled(
@@ -102,11 +150,7 @@ def _post_comment(cloud_id: str, issue_key: str, text: str) -> bool:
     consecutive auth failures the module-level circuit breaker opens and later
     calls short-circuit without hitting the network.
     """
-    global _consecutive_auth_failures, _auth_circuit_open
-
-    with _auth_state_lock:
-        circuit_open = _auth_circuit_open
-    if circuit_open:
+    if _circuit_open():
         log("DEBUG", "jira_reactions: auth circuit still open; short-circuiting call")
         return False
 
@@ -140,24 +184,7 @@ def _post_comment(cloud_id: str, issue_key: str, text: str) -> bool:
         return False
 
     if resp.status_code in (401, 403):
-        with _auth_state_lock:
-            _consecutive_auth_failures += 1
-            opened = (
-                _consecutive_auth_failures >= _AUTH_FAILURE_THRESHOLD and not _auth_circuit_open
-            )
-            if opened:
-                _auth_circuit_open = True
-                failures = _consecutive_auth_failures
-        if opened:
-            log(
-                "ERROR",
-                "jira_reactions: auth circuit OPEN after "
-                f"{failures} consecutive {resp.status_code}s — Jira token likely "
-                "revoked/expired without a working refresh. Suppressing further "
-                "Jira calls for this container.",
-            )
-        else:
-            log("WARN", f"jira_reactions: HTTP {resp.status_code} from Jira (auth)")
+        _note_auth_status(resp.status_code)
         return False
 
     # Jira returns 201 Created on a successful comment.
@@ -165,8 +192,7 @@ def _post_comment(cloud_id: str, issue_key: str, text: str) -> bool:
         log("WARN", f"jira_reactions: HTTP {resp.status_code} from Jira: {resp.text[:200]}")
         return False
 
-    with _auth_state_lock:
-        _consecutive_auth_failures = 0
+    _note_auth_status(resp.status_code)
     return True
 
 
@@ -195,6 +221,246 @@ def comment_task_started(
 # when the agent crashes before completing (max-turns, OOM). The agent only
 # posts the *start* comment (``comment_task_started`` above); posting a terminal
 # comment here too would double-comment on the issue.
+
+
+# ── Workflow transitions (issue #572) ──────────────────────────────────────────
+#
+# Move the originating Jira card across its board as the task progresses so the
+# board reflects reality: To Do → In Progress on start, → In Review on PR. Jira
+# status can only change via the transitions API (``PUT issue`` ignores status),
+# and valid transition IDs are workflow- and current-status-specific, so we
+# resolve them per-issue at call time — never configure or hard-code IDs.
+#
+# Best-effort, exactly like comments: short timeout, errors logged and
+# swallowed, sharing the 401/403 circuit breaker above. A transition failure
+# must never fail, block, or retry the task.
+
+#: Jira ``statusCategory.key`` for the "In Progress" band. The start transition
+#: prefers a destination in this category so standard workflows work with no
+#: per-project config. (Categories: ``new`` = To Do, ``indeterminate`` = In
+#: Progress, ``done`` = Done — the only three, and they are stable API values.)
+_IN_PROGRESS_CATEGORY = "indeterminate"
+
+#: Default destination-name match for the PR-opened transition when no override
+#: is configured. Compared case-insensitively against ``to.name``.
+_DEFAULT_REVIEW_STATUS = "in review"
+
+
+def _get_transitions(cloud_id: str, issue_key: str, token: str) -> list[dict[str, Any]] | None:
+    """GET the transitions valid from the issue's current status.
+
+    Returns the ``transitions`` list (possibly empty) on success, or ``None``
+    on any failure. An empty list is normal — Jira returns one when the OAuth
+    user lacks the *Transition Issues* permission — and callers treat it as
+    "nothing to do", not an error.
+    """
+    url = (
+        f"{JIRA_API_BASE}/{quote(cloud_id, safe='')}"
+        f"/rest/api/3/issue/{quote(issue_key, safe='')}/transitions"
+    )
+    try:
+        resp = requests.get(
+            url,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/json",
+            },
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+    except requests.RequestException as e:
+        log("WARN", f"jira_reactions: transitions GET failed ({type(e).__name__}): {e}")
+        # nosemgrep: py-silent-success-masking -- Jira transitions are best-effort on network blips
+        return None
+
+    if resp.status_code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
+        _note_auth_status(resp.status_code)
+        return None
+    if resp.status_code != HTTPStatus.OK:
+        log("WARN", f"jira_reactions: transitions GET HTTP {resp.status_code}: {resp.text[:200]}")
+        return None
+
+    _note_auth_status(resp.status_code)
+    try:
+        transitions = resp.json().get("transitions", [])
+    except ValueError as e:
+        log("WARN", f"jira_reactions: transitions GET returned non-JSON: {e}")
+        # nosemgrep: py-silent-success-masking -- Jira transitions are best-effort on bad responses
+        return None
+    return transitions if isinstance(transitions, list) else []
+
+
+def _select_transition(
+    transitions: list[dict[str, Any]],
+    *,
+    target_status: str | None,
+    prefer_category: str | None,
+) -> dict[str, Any] | None:
+    """Pick a transition by the resolution ladder, or ``None`` if nothing fits.
+
+    ``target_status`` (a per-project override or the ``In Review`` default) is
+    matched case-insensitively against ``to.name`` first. Only if it is unset
+    does ``prefer_category`` (a ``statusCategory.key``) act as the fallback.
+    Transitions that require a screen are skipped — filling required fields is
+    out of scope and a missing field would 400 the POST.
+    """
+
+    def _usable(t: dict[str, Any]) -> bool:
+        # ``hasScreen`` transitions may demand required fields we can't supply.
+        return isinstance(t, dict) and not t.get("hasScreen", False)
+
+    if target_status:
+        wanted = target_status.strip().lower()
+        for t in transitions:
+            if not _usable(t):
+                continue
+            to_name = (t.get("to") or {}).get("name") or ""
+            if to_name.strip().lower() == wanted:
+                return t
+        # An explicit target that isn't reachable is a deliberate skip — do not
+        # silently fall back to a category heuristic the user didn't ask for.
+        return None
+
+    if prefer_category:
+        for t in transitions:
+            if not _usable(t):
+                continue
+            category = ((t.get("to") or {}).get("statusCategory") or {}).get("key")
+            if category == prefer_category:
+                return t
+    return None
+
+
+def _post_transition(cloud_id: str, issue_key: str, token: str, transition_id: str) -> bool:
+    """POST a transition. Return True on success (204), False on any failure."""
+    url = (
+        f"{JIRA_API_BASE}/{quote(cloud_id, safe='')}"
+        f"/rest/api/3/issue/{quote(issue_key, safe='')}/transitions"
+    )
+    try:
+        resp = requests.post(
+            url,
+            json={"transition": {"id": transition_id}},
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+    except requests.RequestException as e:
+        log("WARN", f"jira_reactions: transition POST failed ({type(e).__name__}): {e}")
+        # nosemgrep: py-silent-success-masking -- Jira transitions are best-effort on network blips
+        return False
+
+    if resp.status_code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
+        _note_auth_status(resp.status_code)
+        return False
+    # Jira returns 204 No Content on a successful transition.
+    if resp.status_code != HTTPStatus.NO_CONTENT:
+        log("WARN", f"jira_reactions: transition POST HTTP {resp.status_code}: {resp.text[:200]}")
+        return False
+
+    _note_auth_status(resp.status_code)
+    return True
+
+
+def _transition(
+    channel_source: str,
+    channel_metadata: dict[str, str] | None,
+    *,
+    lifecycle: str,
+    target_status: str | None,
+    prefer_category: str | None,
+) -> None:
+    """Shared best-effort transition path. No-op for non-Jira tasks.
+
+    Resolves ``(cloud_id, issue_key)``, discovers valid transitions, selects one
+    via the resolution ladder, and POSTs it. Every failure mode — disabled,
+    open circuit, missing token, empty transition list, no match, network /
+    HTTP error — is logged and swallowed so the pipeline is never affected.
+    """
+    target = _enabled(channel_source, channel_metadata)
+    if not target:
+        return
+    cloud_id, issue_key = target
+
+    if _circuit_open():
+        log("DEBUG", "jira_reactions: auth circuit open; skipping transition")
+        return
+
+    token = os.environ.get("JIRA_API_TOKEN", "")
+    if not token:
+        log("WARN", "jira_reactions: JIRA_API_TOKEN not set; skipping transition")
+        return
+
+    transitions = _get_transitions(cloud_id, issue_key, token)
+    if not transitions:
+        # None (error) or [] (no permission / no transitions) — both are skips.
+        log(
+            "WARN",
+            f"jira_reactions: no available transitions for {lifecycle} "
+            f"issue={issue_key} — skipping",
+        )
+        return
+
+    chosen = _select_transition(
+        transitions, target_status=target_status, prefer_category=prefer_category
+    )
+    if not chosen:
+        log(
+            "WARN",
+            f"jira_reactions: no matching {lifecycle} transition for issue={issue_key} "
+            f"(target={target_status!r} category={prefer_category!r}) — skipping",
+        )
+        return
+
+    to_name = (chosen.get("to") or {}).get("name")
+    ok = _post_transition(cloud_id, issue_key, token, str(chosen.get("id")))
+    log(
+        "TASK",
+        f"jira_reactions: transition {lifecycle} issue={issue_key} → {to_name!r} ok={ok}",
+    )
+
+
+def transition_task_started(
+    channel_source: str,
+    channel_metadata: dict[str, str] | None,
+) -> None:
+    """Move the Jira issue to an in-progress status at task start.
+
+    Uses the ``jira_status_on_start`` override when configured, else prefers a
+    transition into the ``indeterminate`` (In Progress) status category.
+    Best-effort; no-op for non-Jira tasks.
+    """
+    override = (channel_metadata or {}).get("jira_status_on_start")
+    _transition(
+        channel_source,
+        channel_metadata,
+        lifecycle="start",
+        target_status=override,
+        prefer_category=None if override else _IN_PROGRESS_CATEGORY,
+    )
+
+
+def transition_pr_opened(
+    channel_source: str,
+    channel_metadata: dict[str, str] | None,
+) -> None:
+    """Move the Jira issue to a review status once a PR is opened.
+
+    Uses the ``jira_status_on_pr`` override when configured, else matches a
+    destination named ``In Review`` (case-insensitive). If neither is
+    reachable, the status is left unchanged. Best-effort; no-op for non-Jira
+    tasks.
+    """
+    override = (channel_metadata or {}).get("jira_status_on_pr")
+    _transition(
+        channel_source,
+        channel_metadata,
+        lifecycle="pr_opened",
+        target_status=override or _DEFAULT_REVIEW_STATUS,
+        prefer_category=None,
+    )
 
 
 def _reset_state_for_testing() -> None:

--- a/agent/src/pipeline.py
+++ b/agent/src/pipeline.py
@@ -23,7 +23,11 @@ from config import (
     resolve_linear_api_token,
 )
 from context import assemble_prompt, fetch_github_issue
-from jira_reactions import comment_task_started
+from jira_reactions import (
+    comment_task_started,
+    transition_pr_opened,
+    transition_task_started,
+)
 from linear_reactions import react_task_finished, react_task_started
 from models import AgentResult, HydratedContext, RepoSetup, TaskConfig, TaskResult
 from observability import current_otel_trace_id, task_span
@@ -862,6 +866,14 @@ def run_task(
                 config.channel_metadata,
             )
 
+            # Move the Jira card To Do → In Progress so the board reflects that
+            # work has started (issue #572). No-op for non-Jira tasks.
+            # Best-effort; failures are logged and never block the pipeline.
+            transition_task_started(
+                config.channel_source,
+                config.channel_metadata,
+            )
+
             # Download attachments from S3 (version-pinned, integrity-verified)
             prepared_attachments: list = []
             if config.attachments:
@@ -1057,6 +1069,14 @@ def run_task(
                 post_span.set_attribute("pr.url", pr_url or "")
             if pr_url:
                 progress.write_agent_milestone("pr_created", pr_url)
+                # Move the Jira card In Progress → In Review now that a PR is
+                # open (issue #572). Only fires when a PR was actually opened —
+                # failed / no-PR tasks leave the card where humans can see the
+                # failure comment. No-op for non-Jira tasks; best-effort.
+                transition_pr_opened(
+                    config.channel_source,
+                    config.channel_metadata,
+                )
 
             # Memory write — capture task episode and repo learnings
             memory_written = False

--- a/agent/tests/test_jira_reactions.py
+++ b/agent/tests/test_jira_reactions.py
@@ -7,7 +7,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import jira_reactions
-from jira_reactions import comment_task_started
+from jira_reactions import (
+    comment_task_started,
+    transition_pr_opened,
+    transition_task_started,
+)
 
 JIRA_META = {"jira_cloud_id": "cloud-1", "jira_issue_key": "KAN-1"}
 
@@ -16,6 +20,29 @@ def _resp(status_code: int = 201, text: str = "") -> MagicMock:
     r = MagicMock()
     r.status_code = status_code
     r.text = text
+    return r
+
+
+def _transition(
+    transition_id: str,
+    to_name: str,
+    *,
+    category: str | None = None,
+    has_screen: bool = False,
+) -> dict:
+    """Build one entry of the transitions API ``transitions[]`` list."""
+    to: dict = {"id": f"s-{transition_id}", "name": to_name}
+    if category is not None:
+        to["statusCategory"] = {"key": category}
+    return {"id": transition_id, "name": to_name, "hasScreen": has_screen, "to": to}
+
+
+def _transitions_resp(*transitions: dict) -> MagicMock:
+    """Build a 200 GET /transitions response wrapping the given transitions."""
+    r = MagicMock()
+    r.status_code = 200
+    r.text = ""
+    r.json.return_value = {"transitions": list(transitions)}
     return r
 
 
@@ -126,3 +153,259 @@ class TestAuthCircuitBreaker:
             comment_task_started("jira", JIRA_META)  # 401, count back to 1
             assert post.call_count == 4
             assert jira_reactions._auth_circuit_open is False
+
+
+class TestTransitionChannelGate:
+    def test_non_jira_source_is_noop(self, monkeypatch):
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        with (
+            patch("jira_reactions.requests.get") as get,
+            patch("jira_reactions.requests.post") as post,
+        ):
+            transition_task_started("linear", JIRA_META)
+            transition_pr_opened("linear", JIRA_META)
+            get.assert_not_called()
+            post.assert_not_called()
+
+    def test_empty_metadata_is_noop(self, monkeypatch):
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        with patch("jira_reactions.requests.get") as get:
+            transition_task_started("jira", None)
+            transition_task_started("jira", {})
+            get.assert_not_called()
+
+    def test_skips_when_token_missing(self, monkeypatch):
+        monkeypatch.delenv("JIRA_API_TOKEN", raising=False)
+        with patch("jira_reactions.requests.get") as get:
+            transition_task_started("jira", JIRA_META)
+            get.assert_not_called()
+
+
+class TestStartTransitionSelection:
+    def test_prefers_indeterminate_category(self, monkeypatch):
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        transitions = _transitions_resp(
+            _transition("11", "Done", category="done"),
+            _transition("21", "In Progress", category="indeterminate"),
+            _transition("31", "Backlog", category="new"),
+        )
+        with (
+            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.post", return_value=_resp(204)) as post,
+        ):
+            transition_task_started("jira", JIRA_META)
+        assert post.call_count == 1
+        url = post.call_args[0][0]
+        assert url == (
+            "https://api.atlassian.com/ex/jira/cloud-1/rest/api/3/issue/KAN-1/transitions"
+        )
+        assert post.call_args[1]["json"] == {"transition": {"id": "21"}}
+
+    def test_override_status_takes_precedence(self, monkeypatch):
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        meta = {**JIRA_META, "jira_status_on_start": "Doing"}
+        transitions = _transitions_resp(
+            _transition("21", "In Progress", category="indeterminate"),
+            _transition("41", "Doing", category="indeterminate"),
+        )
+        with (
+            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.post", return_value=_resp(204)) as post,
+        ):
+            transition_task_started("jira", meta)
+        # Name match on the override wins over the category heuristic.
+        assert post.call_args[1]["json"] == {"transition": {"id": "41"}}
+
+    def test_override_matches_case_insensitively(self, monkeypatch):
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        meta = {**JIRA_META, "jira_status_on_start": "doing"}
+        transitions = _transitions_resp(_transition("41", "Doing", category="indeterminate"))
+        with (
+            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.post", return_value=_resp(204)) as post,
+        ):
+            transition_task_started("jira", meta)
+        assert post.call_args[1]["json"] == {"transition": {"id": "41"}}
+
+    def test_missing_override_target_skips_without_fallback(self, monkeypatch):
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        meta = {**JIRA_META, "jira_status_on_start": "Nonexistent"}
+        transitions = _transitions_resp(
+            _transition("21", "In Progress", category="indeterminate"),
+        )
+        with (
+            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.post") as post,
+        ):
+            transition_task_started("jira", meta)
+        # An explicit override that isn't reachable must NOT fall back to the
+        # category heuristic — it's a deliberate skip.
+        post.assert_not_called()
+
+    def test_no_indeterminate_transition_skips(self, monkeypatch):
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        transitions = _transitions_resp(
+            _transition("11", "Done", category="done"),
+            _transition("31", "Backlog", category="new"),
+        )
+        with (
+            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.post") as post,
+        ):
+            transition_task_started("jira", JIRA_META)
+        post.assert_not_called()
+
+    def test_empty_transition_list_skips(self, monkeypatch):
+        """GET returns [] when the OAuth user lacks Transition Issues perm."""
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        with (
+            patch("jira_reactions.requests.get", return_value=_transitions_resp()),
+            patch("jira_reactions.requests.post") as post,
+        ):
+            transition_task_started("jira", JIRA_META)
+        post.assert_not_called()
+
+    def test_skips_transition_requiring_screen(self, monkeypatch):
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        transitions = _transitions_resp(
+            _transition("21", "In Progress", category="indeterminate", has_screen=True),
+        )
+        with (
+            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.post") as post,
+        ):
+            transition_task_started("jira", JIRA_META)
+        # hasScreen transitions may require fields we can't supply — skip.
+        post.assert_not_called()
+
+
+class TestPrTransitionSelection:
+    def test_matches_in_review_by_name(self, monkeypatch):
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        transitions = _transitions_resp(
+            _transition("21", "In Progress", category="indeterminate"),
+            _transition("51", "In Review", category="indeterminate"),
+        )
+        with (
+            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.post", return_value=_resp(204)) as post,
+        ):
+            transition_pr_opened("jira", JIRA_META)
+        assert post.call_args[1]["json"] == {"transition": {"id": "51"}}
+
+    def test_matches_in_review_case_insensitively(self, monkeypatch):
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        transitions = _transitions_resp(_transition("51", "IN REVIEW"))
+        with (
+            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.post", return_value=_resp(204)) as post,
+        ):
+            transition_pr_opened("jira", JIRA_META)
+        assert post.call_args[1]["json"] == {"transition": {"id": "51"}}
+
+    def test_no_review_status_leaves_unchanged(self, monkeypatch):
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        transitions = _transitions_resp(
+            _transition("21", "In Progress", category="indeterminate"),
+            _transition("11", "Done", category="done"),
+        )
+        with (
+            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.post") as post,
+        ):
+            transition_pr_opened("jira", JIRA_META)
+        # No "In Review"-named destination → status unchanged.
+        post.assert_not_called()
+
+    def test_override_status_on_pr(self, monkeypatch):
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        meta = {**JIRA_META, "jira_status_on_pr": "Code Review"}
+        transitions = _transitions_resp(
+            _transition("51", "In Review"),
+            _transition("61", "Code Review"),
+        )
+        with (
+            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.post", return_value=_resp(204)) as post,
+        ):
+            transition_pr_opened("jira", meta)
+        assert post.call_args[1]["json"] == {"transition": {"id": "61"}}
+
+
+class TestTransitionAuthCircuitBreaker:
+    def test_get_401s_open_shared_breaker(self, monkeypatch):
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        with (
+            patch("jira_reactions.requests.get", return_value=_resp(401)) as get,
+            patch("jira_reactions.requests.post") as post,
+        ):
+            for _ in range(jira_reactions._AUTH_FAILURE_THRESHOLD):
+                transition_task_started("jira", JIRA_META)
+            assert jira_reactions._auth_circuit_open is True
+            calls_after_open = get.call_count
+            # Once open, transitions AND comments short-circuit.
+            transition_task_started("jira", JIRA_META)
+            comment_task_started("jira", JIRA_META)
+            assert get.call_count == calls_after_open
+            post.assert_not_called()
+
+    def test_open_breaker_short_circuits_before_get(self, monkeypatch):
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        # Trip the breaker via comments, then confirm transitions never GET.
+        with patch("jira_reactions.requests.post", return_value=_resp(401)):
+            for _ in range(jira_reactions._AUTH_FAILURE_THRESHOLD):
+                comment_task_started("jira", JIRA_META)
+        assert jira_reactions._auth_circuit_open is True
+        with patch("jira_reactions.requests.get") as get:
+            transition_task_started("jira", JIRA_META)
+            get.assert_not_called()
+
+
+class TestTransitionFailureIsSwallowed:
+    def test_get_500_does_not_raise(self, monkeypatch):
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        with (
+            patch("jira_reactions.requests.get", return_value=_resp(500, "boom")),
+            patch("jira_reactions.requests.post") as post,
+        ):
+            transition_task_started("jira", JIRA_META)
+            post.assert_not_called()
+
+    def test_post_500_does_not_raise(self, monkeypatch):
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        transitions = _transitions_resp(
+            _transition("21", "In Progress", category="indeterminate"),
+        )
+        with (
+            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.post", return_value=_resp(500, "boom")),
+        ):
+            # Must not raise even though the POST fails.
+            transition_task_started("jira", JIRA_META)
+
+    def test_get_request_exception_does_not_raise(self, monkeypatch):
+        import requests
+
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        with (
+            patch(
+                "jira_reactions.requests.get",
+                side_effect=requests.RequestException("network down"),
+            ),
+            patch("jira_reactions.requests.post") as post,
+        ):
+            transition_task_started("jira", JIRA_META)
+            post.assert_not_called()
+
+    def test_non_json_get_does_not_raise(self, monkeypatch):
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        bad = MagicMock()
+        bad.status_code = 200
+        bad.text = "not json"
+        bad.json.side_effect = ValueError("no json")
+        with (
+            patch("jira_reactions.requests.get", return_value=bad),
+            patch("jira_reactions.requests.post") as post,
+        ):
+            transition_task_started("jira", JIRA_META)
+            post.assert_not_called()

--- a/agent/tests/test_jira_reactions.py
+++ b/agent/tests/test_jira_reactions.py
@@ -37,12 +37,23 @@ def _transition(
     return {"id": transition_id, "name": to_name, "hasScreen": has_screen, "to": to}
 
 
-def _transitions_resp(*transitions: dict) -> MagicMock:
-    """Build a 200 GET /transitions response wrapping the given transitions."""
+def _issue_resp(
+    *transitions: dict,
+    current_name: str = "To Do",
+    current_category: str = "new",
+) -> MagicMock:
+    """Build a 200 GET issue (?fields=status&expand=transitions) response.
+
+    Includes both the issue's current ``status`` (default ``To Do``/``new``) and
+    the available ``transitions`` — the shape ``_get_issue_transitions`` reads.
+    """
     r = MagicMock()
     r.status_code = 200
     r.text = ""
-    r.json.return_value = {"transitions": list(transitions)}
+    r.json.return_value = {
+        "fields": {"status": {"name": current_name, "statusCategory": {"key": current_category}}},
+        "transitions": list(transitions),
+    }
     return r
 
 
@@ -182,46 +193,123 @@ class TestTransitionChannelGate:
 
 
 class TestStartTransitionSelection:
-    def test_prefers_indeterminate_category(self, monkeypatch):
+    def test_prefers_in_progress_by_name_over_blocked(self, monkeypatch):
+        """#605: both Blocked and In Progress are `indeterminate`; a name match
+        must land on In Progress regardless of list order."""
         monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
-        transitions = _transitions_resp(
-            _transition("11", "Done", category="done"),
+        # Blocked listed FIRST — a category-only heuristic would wrongly pick it.
+        issue = _issue_resp(
+            _transition("71", "Blocked", category="indeterminate"),
             _transition("21", "In Progress", category="indeterminate"),
-            _transition("31", "Backlog", category="new"),
         )
         with (
-            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.get", return_value=issue),
             patch("jira_reactions.requests.post", return_value=_resp(204)) as post,
         ):
             transition_task_started("jira", JIRA_META)
-        assert post.call_count == 1
-        url = post.call_args[0][0]
-        assert url == (
-            "https://api.atlassian.com/ex/jira/cloud-1/rest/api/3/issue/KAN-1/transitions"
-        )
         assert post.call_args[1]["json"] == {"transition": {"id": "21"}}
+        # POST still goes to the transitions endpoint.
+        assert post.call_args[0][0].endswith("/rest/api/3/issue/KAN-1/transitions")
+
+    def test_falls_back_to_indeterminate_category(self, monkeypatch):
+        """No In-Progress-named transition → any indeterminate (not Blocked)."""
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        issue = _issue_resp(
+            _transition("11", "Done", category="done"),
+            _transition("41", "Doing", category="indeterminate"),
+            _transition("31", "Backlog", category="new"),
+        )
+        with (
+            patch("jira_reactions.requests.get", return_value=issue),
+            patch("jira_reactions.requests.post", return_value=_resp(204)) as post,
+        ):
+            transition_task_started("jira", JIRA_META)
+        assert post.call_args[1]["json"] == {"transition": {"id": "41"}}
+
+    def test_category_fallback_never_picks_blocked(self, monkeypatch):
+        """#605: if the only indeterminate transition is Blocked, skip — the
+        category fallback must not silently land on Blocked."""
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        issue = _issue_resp(
+            _transition("71", "Blocked", category="indeterminate"),
+            _transition("11", "Done", category="done"),
+        )
+        with (
+            patch("jira_reactions.requests.get", return_value=issue),
+            patch("jira_reactions.requests.post") as post,
+        ):
+            transition_task_started("jira", JIRA_META)
+        post.assert_not_called()
+
+    def test_skips_when_already_in_progress(self, monkeypatch):
+        """#605: a re-trigger on an already-In-Progress issue must not move it
+        (and must not move it backward)."""
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        issue = _issue_resp(
+            _transition("31", "To Do", category="new"),
+            current_name="In Progress",
+            current_category="indeterminate",
+        )
+        with (
+            patch("jira_reactions.requests.get", return_value=issue),
+            patch("jira_reactions.requests.post") as post,
+        ):
+            transition_task_started("jira", JIRA_META)
+        post.assert_not_called()
+
+    def test_skips_when_already_in_review(self, monkeypatch):
+        """Already past In Progress (In Review is indeterminate too) → skip."""
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        issue = _issue_resp(
+            _transition("21", "In Progress", category="indeterminate"),
+            current_name="In Review",
+            current_category="indeterminate",
+        )
+        with (
+            patch("jira_reactions.requests.get", return_value=issue),
+            patch("jira_reactions.requests.post") as post,
+        ):
+            transition_task_started("jira", JIRA_META)
+        post.assert_not_called()
 
     def test_override_status_takes_precedence(self, monkeypatch):
         monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
         meta = {**JIRA_META, "jira_status_on_start": "Doing"}
-        transitions = _transitions_resp(
+        issue = _issue_resp(
             _transition("21", "In Progress", category="indeterminate"),
             _transition("41", "Doing", category="indeterminate"),
         )
         with (
-            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.get", return_value=issue),
             patch("jira_reactions.requests.post", return_value=_resp(204)) as post,
         ):
             transition_task_started("jira", meta)
-        # Name match on the override wins over the category heuristic.
+        # Name match on the override wins over the In-Progress name heuristic.
         assert post.call_args[1]["json"] == {"transition": {"id": "41"}}
 
     def test_override_matches_case_insensitively(self, monkeypatch):
         monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
         meta = {**JIRA_META, "jira_status_on_start": "doing"}
-        transitions = _transitions_resp(_transition("41", "Doing", category="indeterminate"))
+        issue = _issue_resp(_transition("41", "Doing", category="indeterminate"))
         with (
-            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.get", return_value=issue),
+            patch("jira_reactions.requests.post", return_value=_resp(204)) as post,
+        ):
+            transition_task_started("jira", meta)
+        assert post.call_args[1]["json"] == {"transition": {"id": "41"}}
+
+    def test_override_honored_even_when_already_in_progress(self, monkeypatch):
+        """An explicit override is a deliberate instruction — honor it
+        regardless of the current status (no already-past skip)."""
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        meta = {**JIRA_META, "jira_status_on_start": "Doing"}
+        issue = _issue_resp(
+            _transition("41", "Doing", category="indeterminate"),
+            current_name="In Progress",
+            current_category="indeterminate",
+        )
+        with (
+            patch("jira_reactions.requests.get", return_value=issue),
             patch("jira_reactions.requests.post", return_value=_resp(204)) as post,
         ):
             transition_task_started("jira", meta)
@@ -230,26 +318,24 @@ class TestStartTransitionSelection:
     def test_missing_override_target_skips_without_fallback(self, monkeypatch):
         monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
         meta = {**JIRA_META, "jira_status_on_start": "Nonexistent"}
-        transitions = _transitions_resp(
-            _transition("21", "In Progress", category="indeterminate"),
-        )
+        issue = _issue_resp(_transition("21", "In Progress", category="indeterminate"))
         with (
-            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.get", return_value=issue),
             patch("jira_reactions.requests.post") as post,
         ):
             transition_task_started("jira", meta)
         # An explicit override that isn't reachable must NOT fall back to the
-        # category heuristic — it's a deliberate skip.
+        # name/category heuristic — it's a deliberate skip.
         post.assert_not_called()
 
     def test_no_indeterminate_transition_skips(self, monkeypatch):
         monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
-        transitions = _transitions_resp(
+        issue = _issue_resp(
             _transition("11", "Done", category="done"),
             _transition("31", "Backlog", category="new"),
         )
         with (
-            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.get", return_value=issue),
             patch("jira_reactions.requests.post") as post,
         ):
             transition_task_started("jira", JIRA_META)
@@ -259,7 +345,7 @@ class TestStartTransitionSelection:
         """GET returns [] when the OAuth user lacks Transition Issues perm."""
         monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
         with (
-            patch("jira_reactions.requests.get", return_value=_transitions_resp()),
+            patch("jira_reactions.requests.get", return_value=_issue_resp()),
             patch("jira_reactions.requests.post") as post,
         ):
             transition_task_started("jira", JIRA_META)
@@ -267,11 +353,11 @@ class TestStartTransitionSelection:
 
     def test_skips_transition_requiring_screen(self, monkeypatch):
         monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
-        transitions = _transitions_resp(
+        issue = _issue_resp(
             _transition("21", "In Progress", category="indeterminate", has_screen=True),
         )
         with (
-            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.get", return_value=issue),
             patch("jira_reactions.requests.post") as post,
         ):
             transition_task_started("jira", JIRA_META)
@@ -282,12 +368,14 @@ class TestStartTransitionSelection:
 class TestPrTransitionSelection:
     def test_matches_in_review_by_name(self, monkeypatch):
         monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
-        transitions = _transitions_resp(
+        issue = _issue_resp(
             _transition("21", "In Progress", category="indeterminate"),
             _transition("51", "In Review", category="indeterminate"),
+            current_name="In Progress",
+            current_category="indeterminate",
         )
         with (
-            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.get", return_value=issue),
             patch("jira_reactions.requests.post", return_value=_resp(204)) as post,
         ):
             transition_pr_opened("jira", JIRA_META)
@@ -295,37 +383,109 @@ class TestPrTransitionSelection:
 
     def test_matches_in_review_case_insensitively(self, monkeypatch):
         monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
-        transitions = _transitions_resp(_transition("51", "IN REVIEW"))
+        issue = _issue_resp(
+            _transition("51", "IN REVIEW", category="indeterminate"),
+            current_name="In Progress",
+            current_category="indeterminate",
+        )
         with (
-            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.get", return_value=issue),
             patch("jira_reactions.requests.post", return_value=_resp(204)) as post,
         ):
             transition_pr_opened("jira", JIRA_META)
         assert post.call_args[1]["json"] == {"transition": {"id": "51"}}
 
-    def test_no_review_status_leaves_unchanged(self, monkeypatch):
+    def test_matches_code_review_synonym(self, monkeypatch):
+        """#605: a 'Code Review' column (no literal 'In Review') still matches."""
         monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
-        transitions = _transitions_resp(
-            _transition("21", "In Progress", category="indeterminate"),
-            _transition("11", "Done", category="done"),
+        issue = _issue_resp(
+            _transition("61", "Code Review", category="indeterminate"),
+            current_name="In Progress",
+            current_category="indeterminate",
         )
         with (
-            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.get", return_value=issue),
+            patch("jira_reactions.requests.post", return_value=_resp(204)) as post,
+        ):
+            transition_pr_opened("jira", JIRA_META)
+        assert post.call_args[1]["json"] == {"transition": {"id": "61"}}
+
+    def test_prefers_in_review_over_code_review(self, monkeypatch):
+        """When both exist, the higher-priority 'In Review' name wins."""
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        issue = _issue_resp(
+            _transition("61", "Code Review", category="indeterminate"),
+            _transition("51", "In Review", category="indeterminate"),
+            current_name="In Progress",
+            current_category="indeterminate",
+        )
+        with (
+            patch("jira_reactions.requests.get", return_value=issue),
+            patch("jira_reactions.requests.post", return_value=_resp(204)) as post,
+        ):
+            transition_pr_opened("jira", JIRA_META)
+        assert post.call_args[1]["json"] == {"transition": {"id": "51"}}
+
+    def test_stock_board_falls_back_to_in_progress(self, monkeypatch):
+        """#605: a board with no review status stays at / moves to In Progress
+        rather than silently no-opping (mirrors Linear's fallback)."""
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        # Issue is still To Do (start hook may have failed); PR hook should at
+        # least advance it to In Progress via the name fallback.
+        issue = _issue_resp(
+            _transition("21", "In Progress", category="indeterminate"),
+            _transition("11", "Done", category="done"),
+            current_name="To Do",
+            current_category="new",
+        )
+        with (
+            patch("jira_reactions.requests.get", return_value=issue),
+            patch("jira_reactions.requests.post", return_value=_resp(204)) as post,
+        ):
+            transition_pr_opened("jira", JIRA_META)
+        assert post.call_args[1]["json"] == {"transition": {"id": "21"}}
+
+    def test_skips_when_already_done(self, monkeypatch):
+        """Only skip the PR transition if the issue is already Done."""
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        issue = _issue_resp(
+            _transition("51", "In Review", category="indeterminate"),
+            current_name="Done",
+            current_category="done",
+        )
+        with (
+            patch("jira_reactions.requests.get", return_value=issue),
             patch("jira_reactions.requests.post") as post,
         ):
             transition_pr_opened("jira", JIRA_META)
-        # No "In Review"-named destination → status unchanged.
+        post.assert_not_called()
+
+    def test_no_review_or_in_progress_leaves_unchanged(self, monkeypatch):
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        issue = _issue_resp(
+            _transition("11", "Done", category="done"),
+            current_name="In Progress",
+            current_category="indeterminate",
+        )
+        with (
+            patch("jira_reactions.requests.get", return_value=issue),
+            patch("jira_reactions.requests.post") as post,
+        ):
+            transition_pr_opened("jira", JIRA_META)
+        # No review-named, no In Progress name, only a Done transition → skip.
         post.assert_not_called()
 
     def test_override_status_on_pr(self, monkeypatch):
         monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
         meta = {**JIRA_META, "jira_status_on_pr": "Code Review"}
-        transitions = _transitions_resp(
-            _transition("51", "In Review"),
-            _transition("61", "Code Review"),
+        issue = _issue_resp(
+            _transition("51", "In Review", category="indeterminate"),
+            _transition("61", "Code Review", category="indeterminate"),
+            current_name="In Progress",
+            current_category="indeterminate",
         )
         with (
-            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.get", return_value=issue),
             patch("jira_reactions.requests.post", return_value=_resp(204)) as post,
         ):
             transition_pr_opened("jira", meta)
@@ -373,11 +533,9 @@ class TestTransitionFailureIsSwallowed:
 
     def test_post_500_does_not_raise(self, monkeypatch):
         monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
-        transitions = _transitions_resp(
-            _transition("21", "In Progress", category="indeterminate"),
-        )
+        issue = _issue_resp(_transition("21", "In Progress", category="indeterminate"))
         with (
-            patch("jira_reactions.requests.get", return_value=transitions),
+            patch("jira_reactions.requests.get", return_value=issue),
             patch("jira_reactions.requests.post", return_value=_resp(500, "boom")),
         ):
             # Must not raise even though the POST fails.
@@ -408,4 +566,20 @@ class TestTransitionFailureIsSwallowed:
             patch("jira_reactions.requests.post") as post,
         ):
             transition_task_started("jira", JIRA_META)
+            post.assert_not_called()
+
+    @pytest.mark.parametrize("body", [None, [], 42, "scalar"])
+    def test_non_dict_json_does_not_raise(self, monkeypatch, body):
+        """#605: valid JSON that isn't an object must not raise AttributeError
+        (which would propagate out of the hook and flip the task to FAILED)."""
+        monkeypatch.setenv("JIRA_API_TOKEN", "jira_at")
+        r = MagicMock()
+        r.status_code = 200
+        r.text = ""
+        r.json.return_value = body
+        with (
+            patch("jira_reactions.requests.get", return_value=r),
+            patch("jira_reactions.requests.post") as post,
+        ):
+            transition_task_started("jira", JIRA_META)  # must not raise
             post.assert_not_called()

--- a/cdk/src/handlers/jira-webhook-processor.ts
+++ b/cdk/src/handlers/jira-webhook-processor.ts
@@ -343,6 +343,19 @@ export async function handler(event: ProcessorEvent): Promise<void> {
     jira_issue_key: issue.key,
   };
 
+  // Optional per-project workflow-transition overrides (issue #572). When an
+  // admin configured `bgagent jira map ... --status-on-start/--status-on-pr`,
+  // stamp them so the agent's best-effort transition helpers prefer these
+  // status names over the built-in statusCategory / "In Review" heuristics.
+  const statusOnStart = mapping.Item.status_on_start as string | undefined;
+  const statusOnPr = mapping.Item.status_on_pr as string | undefined;
+  if (statusOnStart) {
+    channelMetadata.jira_status_on_start = statusOnStart;
+  }
+  if (statusOnPr) {
+    channelMetadata.jira_status_on_pr = statusOnPr;
+  }
+
   // Stash the resolved OAuth secret ARN on the task so the agent runtime
   // doesn't have to re-do the registry lookup. Also blocks tasks from
   // tenants that only verified via the stack-wide fallback (workspace

--- a/cdk/test/handlers/jira-webhook-processor.test.ts
+++ b/cdk/test/handlers/jira-webhook-processor.test.ts
@@ -312,6 +312,44 @@ describe('jira-webhook-processor handler', () => {
     });
   });
 
+  test('stamps status_on_start/status_on_pr overrides into channelMetadata when configured', async () => {
+    ddbSend
+      .mockResolvedValueOnce({
+        Item: {
+          repo: 'org/repo',
+          status: 'active',
+          label_filter: 'bgagent',
+          status_on_start: 'Doing',
+          status_on_pr: 'Code Review',
+        },
+      })
+      .mockResolvedValueOnce({
+        Item: { platform_user_id: 'cognito-user-1', status: 'active' },
+      });
+    createTaskCoreMock.mockResolvedValueOnce({ statusCode: 201, body: '{}' });
+
+    await handler(eventWith(issue()));
+
+    const [, ctx] = createTaskCoreMock.mock.calls[0];
+    expect(ctx.channelMetadata.jira_status_on_start).toBe('Doing');
+    expect(ctx.channelMetadata.jira_status_on_pr).toBe('Code Review');
+  });
+
+  test('omits transition-override metadata when the mapping has no status overrides', async () => {
+    ddbSend
+      .mockResolvedValueOnce({ Item: { repo: 'org/repo', status: 'active', label_filter: 'bgagent' } })
+      .mockResolvedValueOnce({
+        Item: { platform_user_id: 'cognito-user-1', status: 'active' },
+      });
+    createTaskCoreMock.mockResolvedValueOnce({ statusCode: 201, body: '{}' });
+
+    await handler(eventWith(issue()));
+
+    const [, ctx] = createTaskCoreMock.mock.calls[0];
+    expect(ctx.channelMetadata).not.toHaveProperty('jira_status_on_start');
+    expect(ctx.channelMetadata).not.toHaveProperty('jira_status_on_pr');
+  });
+
   test('uses composite project mapping key {cloudId}#{projectKey}', async () => {
     // Two tenants can have the same project key — the composite key
     // disambiguates them. Belt-and-braces test that the lookup uses the

--- a/cli/src/commands/jira.ts
+++ b/cli/src/commands/jira.ts
@@ -947,6 +947,14 @@ export function makeJiraCommand(): Command {
           process.exit(1);
         }
 
+        // Trim transition-status overrides and treat blank/whitespace-only as
+        // unset. A whitespace value is truthy in JS, so without this it would
+        // be persisted and then permanently no-op at the agent (`.strip()` → ""
+        // matches no status, with no fallback) — silently disabling the
+        // project's transition (#605).
+        const statusOnStart = opts.statusOnStart?.trim() || undefined;
+        const statusOnPr = opts.statusOnPr?.trim() || undefined;
+
         const now = new Date().toISOString();
         const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({ region }));
         await ddb.send(new PutCommand({
@@ -960,8 +968,8 @@ export function makeJiraCommand(): Command {
             // Optional per-project workflow-transition overrides (issue #572).
             // Only persisted when supplied so the agent falls back to its
             // statusCategory / "In Review" heuristics otherwise.
-            ...(opts.statusOnStart && { status_on_start: opts.statusOnStart }),
-            ...(opts.statusOnPr && { status_on_pr: opts.statusOnPr }),
+            ...(statusOnStart && { status_on_start: statusOnStart }),
+            ...(statusOnPr && { status_on_pr: statusOnPr }),
             status: 'active',
             onboarded_at: now,
             updated_at: now,
@@ -970,11 +978,11 @@ export function makeJiraCommand(): Command {
 
         console.log(`✓ Mapped Jira project ${cloudId}#${projectKey} → ${opts.repo}`);
         console.log(`  Trigger label: ${opts.label}`);
-        if (opts.statusOnStart) {
-          console.log(`  Status on task start: ${opts.statusOnStart}`);
+        if (statusOnStart) {
+          console.log(`  Status on task start: ${statusOnStart}`);
         }
-        if (opts.statusOnPr) {
-          console.log(`  Status on PR opened: ${opts.statusOnPr}`);
+        if (statusOnPr) {
+          console.log(`  Status on PR opened: ${statusOnPr}`);
         }
       }),
   );

--- a/cli/src/commands/jira.ts
+++ b/cli/src/commands/jira.ts
@@ -922,6 +922,8 @@ export function makeJiraCommand(): Command {
       .argument('<project-key>', 'Jira project key (e.g. ENG)')
       .requiredOption('--repo <owner/repo>', 'GitHub repository the mapped project should route tasks to')
       .option('--label <label>', `Label that triggers a task (default: ${DEFAULT_LABEL_FILTER})`, DEFAULT_LABEL_FILTER)
+      .option('--status-on-start <name>', 'Jira status to move the issue to when a task starts (overrides the In Progress heuristic)')
+      .option('--status-on-pr <name>', 'Jira status to move the issue to when a PR is opened (overrides the "In Review" default)')
       .option('--region <region>', 'AWS region (defaults to configured region)')
       .option('--stack-name <name>', 'CloudFormation stack name', 'backgroundagent-dev')
       .action(async (cloudId: string, projectKey: string, opts) => {
@@ -955,6 +957,11 @@ export function makeJiraCommand(): Command {
             project_key: projectKey,
             repo: opts.repo,
             label_filter: opts.label,
+            // Optional per-project workflow-transition overrides (issue #572).
+            // Only persisted when supplied so the agent falls back to its
+            // statusCategory / "In Review" heuristics otherwise.
+            ...(opts.statusOnStart && { status_on_start: opts.statusOnStart }),
+            ...(opts.statusOnPr && { status_on_pr: opts.statusOnPr }),
             status: 'active',
             onboarded_at: now,
             updated_at: now,
@@ -963,6 +970,12 @@ export function makeJiraCommand(): Command {
 
         console.log(`✓ Mapped Jira project ${cloudId}#${projectKey} → ${opts.repo}`);
         console.log(`  Trigger label: ${opts.label}`);
+        if (opts.statusOnStart) {
+          console.log(`  Status on task start: ${opts.statusOnStart}`);
+        }
+        if (opts.statusOnPr) {
+          console.log(`  Status on PR opened: ${opts.statusOnPr}`);
+        }
       }),
   );
 

--- a/cli/test/commands/jira.test.ts
+++ b/cli/test/commands/jira.test.ts
@@ -134,6 +134,76 @@ describe('makeJiraCommand', () => {
     // `--repo` is required on map.
     expect(map!.options.find((o) => o.long === '--repo')?.required).toBe(true);
   });
+
+  test('`map` exposes optional --status-on-start / --status-on-pr flags', () => {
+    const cmd = makeJiraCommand();
+    const map = cmd.commands.find((c) => c.name() === 'map');
+    const startOpt = map!.options.find((o) => o.long === '--status-on-start');
+    const prOpt = map!.options.find((o) => o.long === '--status-on-pr');
+    expect(startOpt).toBeDefined();
+    expect(prOpt).toBeDefined();
+    // Optional: not mandatory and no default value (so the agent falls back to
+    // its heuristics when unset). `.required` here is Commander's "the option
+    // *argument* is required when the flag is present" (from `<name>`), not
+    // "the flag is mandatory" — that's `.mandatory`.
+    expect(startOpt!.mandatory).toBeFalsy();
+    expect(prOpt!.mandatory).toBeFalsy();
+    expect(startOpt!.defaultValue).toBeUndefined();
+    expect(prOpt!.defaultValue).toBeUndefined();
+  });
+});
+
+describe('jira map action', () => {
+  let loadConfigSpy: jest.SpiedFunction<typeof config.loadConfig>;
+  let logSpy: jest.SpiedFunction<typeof console.log>;
+
+  beforeEach(() => {
+    ddbSend.mockReset().mockResolvedValue({});
+    cfnSend.mockReset().mockResolvedValue({
+      Stacks: [{
+        Outputs: [
+          { OutputKey: 'JiraProjectMappingTableName', OutputValue: 'JiraProjectsTable' },
+        ],
+      }],
+    });
+    loadConfigSpy = jest.spyOn(config, 'loadConfig').mockReturnValue({ region: 'us-west-2' } as ReturnType<typeof config.loadConfig>);
+    logSpy = jest.spyOn(console, 'log').mockImplementation();
+  });
+
+  afterEach(() => {
+    loadConfigSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  test('persists status_on_start / status_on_pr when both flags are supplied', async () => {
+    const program = makeJiraCommand();
+    await program.parseAsync([
+      'node', 'bgagent', 'map', 'cloud-1', 'ENG',
+      '--repo', 'org/repo',
+      '--status-on-start', 'Doing',
+      '--status-on-pr', 'Code Review',
+    ]);
+
+    const putCmd = ddbSend.mock.calls[0][0] as PutCommand;
+    expect(putCmd).toBeInstanceOf(PutCommand);
+    expect(putCmd.input.Item).toMatchObject({
+      jira_project_identity: 'cloud-1#ENG',
+      repo: 'org/repo',
+      status_on_start: 'Doing',
+      status_on_pr: 'Code Review',
+    });
+  });
+
+  test('omits status_on_* keys entirely when the flags are not supplied', async () => {
+    const program = makeJiraCommand();
+    await program.parseAsync([
+      'node', 'bgagent', 'map', 'cloud-1', 'ENG', '--repo', 'org/repo',
+    ]);
+
+    const putCmd = ddbSend.mock.calls[0][0] as PutCommand;
+    expect(putCmd.input.Item).not.toHaveProperty('status_on_start');
+    expect(putCmd.input.Item).not.toHaveProperty('status_on_pr');
+  });
 });
 
 describe('generateInviteCode', () => {

--- a/cli/test/commands/jira.test.ts
+++ b/cli/test/commands/jira.test.ts
@@ -204,6 +204,33 @@ describe('jira map action', () => {
     expect(putCmd.input.Item).not.toHaveProperty('status_on_start');
     expect(putCmd.input.Item).not.toHaveProperty('status_on_pr');
   });
+
+  test('trims override values before persisting', async () => {
+    const program = makeJiraCommand();
+    await program.parseAsync([
+      'node', 'bgagent', 'map', 'cloud-1', 'ENG', '--repo', 'org/repo',
+      '--status-on-start', '  Doing  ',
+      '--status-on-pr', '  Code Review  ',
+    ]);
+
+    const putCmd = ddbSend.mock.calls[0][0] as PutCommand;
+    expect(putCmd.input.Item).toMatchObject({ status_on_start: 'Doing', status_on_pr: 'Code Review' });
+  });
+
+  test('treats whitespace-only overrides as unset (not persisted)', async () => {
+    // #605: a truthy whitespace value would otherwise persist and permanently
+    // no-op at the agent (strip() -> "" matches no status, no fallback).
+    const program = makeJiraCommand();
+    await program.parseAsync([
+      'node', 'bgagent', 'map', 'cloud-1', 'ENG', '--repo', 'org/repo',
+      '--status-on-start', '   ',
+      '--status-on-pr', '\t',
+    ]);
+
+    const putCmd = ddbSend.mock.calls[0][0] as PutCommand;
+    expect(putCmd.input.Item).not.toHaveProperty('status_on_start');
+    expect(putCmd.input.Item).not.toHaveProperty('status_on_pr');
+  });
 });
 
 describe('generateInviteCode', () => {

--- a/docs/guides/JIRA_SETUP_GUIDE.md
+++ b/docs/guides/JIRA_SETUP_GUIDE.md
@@ -48,6 +48,19 @@ task reaches a terminal event (completed / failed / cancelled /
   PR link, via the same REST v3 comment endpoint
 ```
 
+Outbound board transitions (Agent → Jira) — REST v3:
+
+```
+task starts → agent moves the issue to an In Progress status via
+  POST api.atlassian.com/ex/jira/{cloudId}/rest/api/3/issue/{key}/transitions
+PR opened → agent moves the issue to an "In Review" status via the same endpoint
+```
+
+So the Jira board reflects the task lifecycle at a glance, the agent transitions
+the originating issue as it works — the same signal Linear-origin tasks already
+give. See [Board transitions](#board-transitions) below for the resolution order
+and the permission it requires.
+
 The **start** comment is posted by the agent. The **terminal** comment is
 posted by the platform's fan-out plane, not the agent — so it always includes
 cost / turns / duration and fires even when the agent crashes before
@@ -133,6 +146,8 @@ bgagent jira map <cloud-id> <PROJECT-KEY> --repo owner/repo
 - `<PROJECT-KEY>` — the Jira project key, e.g. `ENG` (uppercase, starts with a letter)
 - `--repo owner/repo` — the GitHub repository tasks from this project route to
 - `--label <name>` — trigger label (default `bgagent`)
+- `--status-on-start <name>` — Jira status to move the issue to when a task starts (overrides the heuristic; see [Board transitions](#board-transitions))
+- `--status-on-pr <name>` — Jira status to move the issue to when a PR is opened (overrides the `In Review` default)
 
 This writes an `active` row keyed `<cloudId>#<projectKey>` into the project-mapping table. Requires admin IAM (it writes DynamoDB directly).
 
@@ -181,6 +196,30 @@ The body must be verified as the *raw unparsed bytes* — never parsed-and-restr
 - **`jira:issue_updated`** — triggers only if the label was **newly added** in this update. Jira reports label changes in `changelog.items[]` (`field: "labels"`, with `fromString` / `toString`), *not* by re-sending the full label list. The processor diffs the changelog rather than inspecting `issue.fields.labels`, so re-saving an issue that already has the label does not re-trigger.
 - All other event types get a silent `200`.
 
+## Board transitions
+
+As a Jira-triggered task progresses, the agent moves the originating issue across its workflow so the board reflects reality — the same at-a-glance signal Linear-origin tasks already give:
+
+- **Task start** → the issue moves to an **In Progress** status.
+- **PR opened** → the issue moves to a status named **In Review** (when the workflow has one).
+- **Task failed or no PR opened** → the status is **left unchanged**; the ❌ final-status comment is the signal, and bouncing a card back and forth is noisier than leaving it where a human sees the failure.
+
+Humans still move the card to **Done** after merging the PR — ABCA never closes issues.
+
+**How a target status is resolved** (evaluated per lifecycle point, first match wins):
+
+1. **Per-project override** — the `--status-on-start` / `--status-on-pr` names configured on the project mapping. Matched case-insensitively against the destination status name. An override that isn't reachable from the current status is a deliberate skip (no fallback).
+2. **Heuristic** (no config needed for standard workflows):
+   - On start, the transition whose destination `statusCategory` is *In Progress* (`indeterminate`).
+   - On PR opened, a transition whose destination is named `In Review` (case-insensitive).
+3. **Skip with a warning** — nothing matches, the transition requires a screen with required fields, or the authorizing user lacks permission. The task is never affected.
+
+Transitions are **best-effort**, exactly like comments: short timeout, errors logged and swallowed, sharing the same `401`/`403` auth circuit breaker. A transition failure never fails, blocks, or retries the task. Transition IDs are workflow- and current-status-specific, so they are resolved per-issue at call time (by matching destination name / category) — never configured or hard-coded.
+
+> **Permission prerequisite.** The transition uses the existing `read:jira-work` / `write:jira-work` scopes — **no new OAuth scopes and no re-authorization**. OAuth scopes do not, however, override Jira **project permissions**: the authorizing user must have the **Transition Issues** permission in each mapped project. When they don't, Jira's *get transitions* call returns an empty list (not an error), so ABCA simply skips the transition and logs a warning — comments still post as normal.
+
+The feature targets Jira **statuses**, not board columns. Because moving a card between columns *is* a status transition under the hood, no board-configuration API is involved. Multi-hop pathfinding is out of scope: if no single transition reaches the target from the current status, ABCA skips.
+
 ## Webhook dedup
 
 The receiver dedupes on `{issueKey}#{webhookEventTimestamp}` with an 8-hour TTL. Using the event timestamp (rather than event type) means two distinct label-adds in quick succession are not collapsed. Jira retries far less aggressively than Linear, so 8 hours is safe parity.
@@ -225,8 +264,18 @@ Expected, not a broken install. The stored access token lives ~1 hour and is onl
 
 - Verify the per-tenant OAuth secret exists: `aws secretsmanager describe-secret --secret-id bgagent-jira-oauth-<cloudId>`.
 - Verify the registry row's `oauth_secret_arn` matches and `status = 'active'`.
-- Check the agent container logs for `jira_reactions` lines (`comment_task_started` / `comment_task_finished`). Absence means `channel_source` wasn't `jira` on the task, or the tenant OAuth token didn't resolve. (The `jira-server` MCP entry is also written to `.mcp.json`, but it is a non-functional placeholder — its connection failure is expected and is not the cause.)
+- Check the agent container logs for `jira_reactions` lines (`comment_task_started`). Absence means `channel_source` wasn't `jira` on the task, or the tenant OAuth token didn't resolve. (The `jira-server` MCP entry is also written to `.mcp.json`, but it is a non-functional placeholder — its connection failure is expected and is not the cause.)
 - A `401`/`403` from Atlassian usually means the token was revoked tenant-side, or the stored access token expired and the agent (which never refreshes) failed closed — re-run `bgagent jira setup` to re-mint, then re-apply the label.
+
+### Jira card doesn't move across the board
+
+Board transitions are best-effort and never block the task, so a card can stay put while comments still post. Common causes:
+
+- **The authorizing user lacks *Transition Issues* permission** in the project. Jira then returns an empty transition list and ABCA skips with a warning. Grant the permission to the account that ran `bgagent jira setup`.
+- **No matching destination.** The standard heuristics look for an *In Progress*-category status on start and an `In Review`-named status on PR. Custom workflows may name these differently — configure `bgagent jira map ... --status-on-start "<name>" --status-on-pr "<name>"`.
+- **The transition requires a screen** with required fields. ABCA skips these by design (it can't fill required fields) — pick a screen-less transition or remove the required fields from the workflow.
+- **No single-hop transition reaches the target** from the issue's current status. ABCA does not chain transitions.
+- Check the agent container logs for `jira_reactions: transition …` lines — they name the chosen destination or the skip reason.
 
 ## Limits and quotas
 

--- a/docs/guides/JIRA_SETUP_GUIDE.md
+++ b/docs/guides/JIRA_SETUP_GUIDE.md
@@ -201,18 +201,20 @@ The body must be verified as the *raw unparsed bytes* — never parsed-and-restr
 As a Jira-triggered task progresses, the agent moves the originating issue across its workflow so the board reflects reality — the same at-a-glance signal Linear-origin tasks already give:
 
 - **Task start** → the issue moves to an **In Progress** status.
-- **PR opened** → the issue moves to a status named **In Review** (when the workflow has one).
+- **PR opened** → the issue moves to a **review** status (default **In Review**, falling back to In Progress so a stock board isn't skipped).
 - **Task failed or no PR opened** → the status is **left unchanged**; the ❌ final-status comment is the signal, and bouncing a card back and forth is noisier than leaving it where a human sees the failure.
+- **Already at or past the target** → the transition is **skipped**, so a re-triggered task never drags a card backward (e.g. from In Review back to In Progress). This mirrors the Linear integration.
 
 Humans still move the card to **Done** after merging the PR — ABCA never closes issues.
 
-**How a target status is resolved** (evaluated per lifecycle point, first match wins):
+**How a target status is resolved** (evaluated per lifecycle point, first match wins — modeled on the Linear integration):
 
-1. **Per-project override** — the `--status-on-start` / `--status-on-pr` names configured on the project mapping. Matched case-insensitively against the destination status name. An override that isn't reachable from the current status is a deliberate skip (no fallback).
-2. **Heuristic** (no config needed for standard workflows):
-   - On start, the transition whose destination `statusCategory` is *In Progress* (`indeterminate`).
-   - On PR opened, a transition whose destination is named `In Review` (case-insensitive).
-3. **Skip with a warning** — nothing matches, the transition requires a screen with required fields, or the authorizing user lacks permission. The task is never affected.
+1. **Per-project override** — the `--status-on-start` / `--status-on-pr` names configured on the project mapping. Matched case-insensitively against the destination status name. An override is a deliberate instruction: it's honored regardless of the current status, and if it isn't reachable, ABCA skips (no heuristic fallback).
+2. **Name match** (no config needed for standard workflows):
+   - On start, a transition whose destination is named **In Progress**.
+   - On PR opened, a transition named **In Review**, then common synonyms (`Code Review`, `Review`, `Peer Review`, `Reviewing`), then **In Progress** as a last resort.
+3. **Category fallback** — any transition whose destination `statusCategory` is *In Progress* (`indeterminate`), **excluding `Blocked`** (which shares that category but is never what "move to In Progress" means). The name match in step 2 is what keeps the heuristic from landing on `Blocked` when both are available.
+4. **Skip with a warning** — nothing matches, the transition requires a screen with required fields, or the authorizing user lacks permission. The task is never affected.
 
 Transitions are **best-effort**, exactly like comments: short timeout, errors logged and swallowed, sharing the same `401`/`403` auth circuit breaker. A transition failure never fails, blocks, or retries the task. Transition IDs are workflow- and current-status-specific, so they are resolved per-issue at call time (by matching destination name / category) — never configured or hard-coded.
 

--- a/docs/src/content/docs/using/Jira-setup-guide.md
+++ b/docs/src/content/docs/using/Jira-setup-guide.md
@@ -205,18 +205,20 @@ The body must be verified as the *raw unparsed bytes* — never parsed-and-restr
 As a Jira-triggered task progresses, the agent moves the originating issue across its workflow so the board reflects reality — the same at-a-glance signal Linear-origin tasks already give:
 
 - **Task start** → the issue moves to an **In Progress** status.
-- **PR opened** → the issue moves to a status named **In Review** (when the workflow has one).
+- **PR opened** → the issue moves to a **review** status (default **In Review**, falling back to In Progress so a stock board isn't skipped).
 - **Task failed or no PR opened** → the status is **left unchanged**; the ❌ final-status comment is the signal, and bouncing a card back and forth is noisier than leaving it where a human sees the failure.
+- **Already at or past the target** → the transition is **skipped**, so a re-triggered task never drags a card backward (e.g. from In Review back to In Progress). This mirrors the Linear integration.
 
 Humans still move the card to **Done** after merging the PR — ABCA never closes issues.
 
-**How a target status is resolved** (evaluated per lifecycle point, first match wins):
+**How a target status is resolved** (evaluated per lifecycle point, first match wins — modeled on the Linear integration):
 
-1. **Per-project override** — the `--status-on-start` / `--status-on-pr` names configured on the project mapping. Matched case-insensitively against the destination status name. An override that isn't reachable from the current status is a deliberate skip (no fallback).
-2. **Heuristic** (no config needed for standard workflows):
-   - On start, the transition whose destination `statusCategory` is *In Progress* (`indeterminate`).
-   - On PR opened, a transition whose destination is named `In Review` (case-insensitive).
-3. **Skip with a warning** — nothing matches, the transition requires a screen with required fields, or the authorizing user lacks permission. The task is never affected.
+1. **Per-project override** — the `--status-on-start` / `--status-on-pr` names configured on the project mapping. Matched case-insensitively against the destination status name. An override is a deliberate instruction: it's honored regardless of the current status, and if it isn't reachable, ABCA skips (no heuristic fallback).
+2. **Name match** (no config needed for standard workflows):
+   - On start, a transition whose destination is named **In Progress**.
+   - On PR opened, a transition named **In Review**, then common synonyms (`Code Review`, `Review`, `Peer Review`, `Reviewing`), then **In Progress** as a last resort.
+3. **Category fallback** — any transition whose destination `statusCategory` is *In Progress* (`indeterminate`), **excluding `Blocked`** (which shares that category but is never what "move to In Progress" means). The name match in step 2 is what keeps the heuristic from landing on `Blocked` when both are available.
+4. **Skip with a warning** — nothing matches, the transition requires a screen with required fields, or the authorizing user lacks permission. The task is never affected.
 
 Transitions are **best-effort**, exactly like comments: short timeout, errors logged and swallowed, sharing the same `401`/`403` auth circuit breaker. A transition failure never fails, blocks, or retries the task. Transition IDs are workflow- and current-status-specific, so they are resolved per-issue at call time (by matching destination name / category) — never configured or hard-coded.
 

--- a/docs/src/content/docs/using/Jira-setup-guide.md
+++ b/docs/src/content/docs/using/Jira-setup-guide.md
@@ -52,6 +52,19 @@ task reaches a terminal event (completed / failed / cancelled /
   PR link, via the same REST v3 comment endpoint
 ```
 
+Outbound board transitions (Agent → Jira) — REST v3:
+
+```
+task starts → agent moves the issue to an In Progress status via
+  POST api.atlassian.com/ex/jira/{cloudId}/rest/api/3/issue/{key}/transitions
+PR opened → agent moves the issue to an "In Review" status via the same endpoint
+```
+
+So the Jira board reflects the task lifecycle at a glance, the agent transitions
+the originating issue as it works — the same signal Linear-origin tasks already
+give. See [Board transitions](#board-transitions) below for the resolution order
+and the permission it requires.
+
 The **start** comment is posted by the agent. The **terminal** comment is
 posted by the platform's fan-out plane, not the agent — so it always includes
 cost / turns / duration and fires even when the agent crashes before
@@ -137,6 +150,8 @@ bgagent jira map <cloud-id> <PROJECT-KEY> --repo owner/repo
 - `<PROJECT-KEY>` — the Jira project key, e.g. `ENG` (uppercase, starts with a letter)
 - `--repo owner/repo` — the GitHub repository tasks from this project route to
 - `--label <name>` — trigger label (default `bgagent`)
+- `--status-on-start <name>` — Jira status to move the issue to when a task starts (overrides the heuristic; see [Board transitions](#board-transitions))
+- `--status-on-pr <name>` — Jira status to move the issue to when a PR is opened (overrides the `In Review` default)
 
 This writes an `active` row keyed `<cloudId>#<projectKey>` into the project-mapping table. Requires admin IAM (it writes DynamoDB directly).
 
@@ -185,6 +200,30 @@ The body must be verified as the *raw unparsed bytes* — never parsed-and-restr
 - **`jira:issue_updated`** — triggers only if the label was **newly added** in this update. Jira reports label changes in `changelog.items[]` (`field: "labels"`, with `fromString` / `toString`), *not* by re-sending the full label list. The processor diffs the changelog rather than inspecting `issue.fields.labels`, so re-saving an issue that already has the label does not re-trigger.
 - All other event types get a silent `200`.
 
+## Board transitions
+
+As a Jira-triggered task progresses, the agent moves the originating issue across its workflow so the board reflects reality — the same at-a-glance signal Linear-origin tasks already give:
+
+- **Task start** → the issue moves to an **In Progress** status.
+- **PR opened** → the issue moves to a status named **In Review** (when the workflow has one).
+- **Task failed or no PR opened** → the status is **left unchanged**; the ❌ final-status comment is the signal, and bouncing a card back and forth is noisier than leaving it where a human sees the failure.
+
+Humans still move the card to **Done** after merging the PR — ABCA never closes issues.
+
+**How a target status is resolved** (evaluated per lifecycle point, first match wins):
+
+1. **Per-project override** — the `--status-on-start` / `--status-on-pr` names configured on the project mapping. Matched case-insensitively against the destination status name. An override that isn't reachable from the current status is a deliberate skip (no fallback).
+2. **Heuristic** (no config needed for standard workflows):
+   - On start, the transition whose destination `statusCategory` is *In Progress* (`indeterminate`).
+   - On PR opened, a transition whose destination is named `In Review` (case-insensitive).
+3. **Skip with a warning** — nothing matches, the transition requires a screen with required fields, or the authorizing user lacks permission. The task is never affected.
+
+Transitions are **best-effort**, exactly like comments: short timeout, errors logged and swallowed, sharing the same `401`/`403` auth circuit breaker. A transition failure never fails, blocks, or retries the task. Transition IDs are workflow- and current-status-specific, so they are resolved per-issue at call time (by matching destination name / category) — never configured or hard-coded.
+
+> **Permission prerequisite.** The transition uses the existing `read:jira-work` / `write:jira-work` scopes — **no new OAuth scopes and no re-authorization**. OAuth scopes do not, however, override Jira **project permissions**: the authorizing user must have the **Transition Issues** permission in each mapped project. When they don't, Jira's *get transitions* call returns an empty list (not an error), so ABCA simply skips the transition and logs a warning — comments still post as normal.
+
+The feature targets Jira **statuses**, not board columns. Because moving a card between columns *is* a status transition under the hood, no board-configuration API is involved. Multi-hop pathfinding is out of scope: if no single transition reaches the target from the current status, ABCA skips.
+
 ## Webhook dedup
 
 The receiver dedupes on `{issueKey}#{webhookEventTimestamp}` with an 8-hour TTL. Using the event timestamp (rather than event type) means two distinct label-adds in quick succession are not collapsed. Jira retries far less aggressively than Linear, so 8 hours is safe parity.
@@ -229,8 +268,18 @@ Expected, not a broken install. The stored access token lives ~1 hour and is onl
 
 - Verify the per-tenant OAuth secret exists: `aws secretsmanager describe-secret --secret-id bgagent-jira-oauth-<cloudId>`.
 - Verify the registry row's `oauth_secret_arn` matches and `status = 'active'`.
-- Check the agent container logs for `jira_reactions` lines (`comment_task_started` / `comment_task_finished`). Absence means `channel_source` wasn't `jira` on the task, or the tenant OAuth token didn't resolve. (The `jira-server` MCP entry is also written to `.mcp.json`, but it is a non-functional placeholder — its connection failure is expected and is not the cause.)
+- Check the agent container logs for `jira_reactions` lines (`comment_task_started`). Absence means `channel_source` wasn't `jira` on the task, or the tenant OAuth token didn't resolve. (The `jira-server` MCP entry is also written to `.mcp.json`, but it is a non-functional placeholder — its connection failure is expected and is not the cause.)
 - A `401`/`403` from Atlassian usually means the token was revoked tenant-side, or the stored access token expired and the agent (which never refreshes) failed closed — re-run `bgagent jira setup` to re-mint, then re-apply the label.
+
+### Jira card doesn't move across the board
+
+Board transitions are best-effort and never block the task, so a card can stay put while comments still post. Common causes:
+
+- **The authorizing user lacks *Transition Issues* permission** in the project. Jira then returns an empty transition list and ABCA skips with a warning. Grant the permission to the account that ran `bgagent jira setup`.
+- **No matching destination.** The standard heuristics look for an *In Progress*-category status on start and an `In Review`-named status on PR. Custom workflows may name these differently — configure `bgagent jira map ... --status-on-start "<name>" --status-on-pr "<name>"`.
+- **The transition requires a screen** with required fields. ABCA skips these by design (it can't fill required fields) — pick a screen-less transition or remove the required fields from the workflow.
+- **No single-hop transition reaches the target** from the issue's current status. ABCA does not chain transitions.
+- Check the agent container logs for `jira_reactions: transition …` lines — they name the chosen destination or the skip reason.
 
 ## Limits and quotas
 


### PR DESCRIPTION
## What

Moves the originating Jira issue through its workflow as an ABCA task progresses, so the Jira board reflects the task lifecycle at a glance — the same signal Linear-origin tasks already give:

- **Task start** → In Progress
- **PR opened** → In Review
- **Failed / no PR** → status unchanged

Closes #572.

## How

- **`agent/src/jira_reactions.py`** — new best-effort `transition_task_started` / `transition_pr_opened` helpers: `GET /transitions` → select via the resolution ladder → `POST /transitions`. Extracted the 401/403 circuit-breaker accounting (`_note_auth_status` / `_circuit_open`) so comments and transitions share one breaker.
- **`agent/src/pipeline.py`** — invoke the helpers at the existing start hook and the success-path PR hook (only when a PR was actually opened).
- **`cdk/src/handlers/jira-webhook-processor.ts`** — stamp optional `jira_status_on_start` / `jira_status_on_pr` from the project mapping into `channel_metadata`.
- **`cli/src/commands/jira.ts`** — optional `--status-on-start` / `--status-on-pr` on `bgagent jira map`.
- **`docs/guides/JIRA_SETUP_GUIDE.md`** — Board transitions section (defaults, overrides, *Transition Issues* permission prerequisite) + troubleshooting; Starlight mirror regenerated.

### Status resolution ladder (per lifecycle point)

1. **Per-project override** — `--status-on-start` / `--status-on-pr`, matched case-insensitively against the destination name. An unreachable override is a deliberate skip (no fallback).
2. **Heuristic** — on start, destination `statusCategory == indeterminate`; on PR, destination named `In Review`.
3. **Skip with a warning** — no match, `hasScreen` transition, or empty transition list (user lacks *Transition Issues* permission).

## Safety

- Best-effort throughout: short timeout, errors logged and swallowed, shared auth circuit breaker. A transition failure never fails, blocks, or retries the task.
- **No new OAuth scopes** — existing `read:jira-work` / `write:jira-work` cover both the transitions GET and POST.
- No multi-hop pathfinding, no screen-field filling, no move-to-Done — all explicitly out of scope.

## Tests

- **Agent** (`test_jira_reactions.py`): channel gate, start category heuristic, PR name-match, per-project overrides + precedence, case-insensitive match, unreachable-override skip, `hasScreen` skip, empty-list skip, shared circuit breaker (GET 401s open it; open breaker short-circuits before GET), and failure isolation (GET/POST 500, request exceptions, non-JSON). 30 pass.
- **CDK** (`jira-webhook-processor.test.ts`): overrides stamped when configured; keys omitted when absent. 43 pass.
- **CLI** (`jira.test.ts`): flags registered as optional; persisted to the mapping row when supplied, omitted when not. 59 pass.

`mise run build` green. Security secrets/masking findings are pre-existing baseline noise (history scan + `linear_reactions.py` etc.); the new best-effort returns carry `nosemgrep` annotations matching the sibling module.