### PR TITLE
fix(cli): linear setup must not clobber a workspace's webhook signing secret (#611)

### DIFF
--- a/cli/src/commands/linear.ts
+++ b/cli/src/commands/linear.ts
@@ -43,6 +43,7 @@ import {
   generatePkce,
   LINEAR_OAUTH_SECRET_PREFIX,
   linearOauthSecretName,
+  readExistingWebhookSecret,
   resolveWebhookSecretAction,
   StoredLinearOauthToken,
 } from '../linear-oauth';
@@ -609,17 +610,34 @@ export function makeLinearCommand(): Command {
         // first) — that silently breaks signature verification (401 "Invalid
         // signature") for every workspace after the first in a multi-workspace
         // deployment. Rotation stays the job of `update-webhook-secret`.
+        // Fail CLOSED (#612 review B1): read this workspace's existing signing
+        // secret before the overwrite. Only ResourceNotFoundException is a clean
+        // first-install; any other SM error (AccessDenied, KMSAccessDenied,
+        // Throttling, network) — or a corrupt bundle — must surface, NOT default
+        // to undefined (which would mirror the stack-wide secret over a working
+        // per-workspace one → the #611 401 clobber, silently, behind a green
+        // "Setup complete"). Extracted to readExistingWebhookSecret + unit-tested.
         let existingWebhookSecret: string | undefined;
         try {
-          const prior = await sm.send(new GetSecretValueCommand({ SecretId: linearOauthSecretName(slug) }));
-          if (prior.SecretString) {
-            const priorBundle = JSON.parse(prior.SecretString) as Partial<StoredLinearOauthToken>;
-            if (priorBundle.webhook_signing_secret?.startsWith('lin_wh_')) {
-              existingWebhookSecret = priorBundle.webhook_signing_secret;
-            }
-          }
-        } catch {
-          // No prior bundle (first install) — nothing to preserve.
+          existingWebhookSecret = await readExistingWebhookSecret(
+            async () => {
+              const prior = await sm.send(new GetSecretValueCommand({ SecretId: linearOauthSecretName(slug) }));
+              return prior.SecretString;
+            },
+            (err) => (err as { name?: string }).name === 'ResourceNotFoundException',
+          );
+        } catch (err) {
+          const errorName = (err as { name?: string }).name;
+          const message = err instanceof Error ? err.message : String(err);
+          throw new CliError(
+            `Failed to read the existing Linear webhook secret for '${slug}' before re-write: `
+            + `${errorName ?? 'Error'}: ${message}. Refusing to proceed — continuing could clobber `
+            + 'this workspace\'s webhook signing secret with the stack-wide value (a 401 on every '
+            + 'delivery). Likely an IAM/KMS gap: confirm your CLI principal has '
+            + '`secretsmanager:GetSecretValue` (and kms:Decrypt if a CMK) on '
+            + `${linearOauthSecretName(slug)}, or run \`bgagent linear update-webhook-secret ${slug}\` `
+            + 'after fixing access.',
+          );
         }
         const stored: StoredLinearOauthToken = {
           access_token: tokenResponse.access_token,
@@ -635,6 +653,14 @@ export function makeLinearCommand(): Command {
           installed_at: now,
           updated_at: now,
           installed_by_platform_user_id: cognitoSub,
+          // Fold the preserved secret into the INITIAL bundle (#612 review N2):
+          // the OAuth-secret write below then lands the correct bundle in ONE
+          // PutSecretValue, and the preserve path skips the later re-write. This
+          // also closes a narrow window — if any fallible step between the two
+          // writes threw, the bundle was left persisted WITHOUT the secret (401
+          // until update-webhook-secret). Only set for a real `lin_wh_` value;
+          // mirror-stackwide / prompt cases add it in the mirror-back below.
+          ...(existingWebhookSecret ? { webhook_signing_secret: existingWebhookSecret } : {}),
         };
         if (!stored.refresh_token) {
           throw new CliError(
@@ -696,14 +722,21 @@ export function makeLinearCommand(): Command {
         // without re-onboarding. Multi-workspace installs need each
         // workspace to own its own per-workspace signing secret — only
         // the FIRST install can populate the stack-wide one usefully.
-        // If stack-wide is already populated, this is either a re-run
-        // of setup on the SAME workspace or the FIRST workspace of a
-        // future multi-workspace install. Either way the stored value
-        // is this workspace's signing secret — lift it into the
-        // per-workspace bundle without prompting (auto-migration to
-        // the new shape). Rotation is not setup's job: use
-        // `bgagent linear update-webhook-secret <slug>` to rotate the
-        // signing secret without re-running OAuth.
+        //
+        // resolveWebhookSecretAction picks one of three outcomes from
+        // (existingWebhookSecret, stackWideAlreadyConfigured):
+        //   • preserve      — this workspace ALREADY has its own `lin_wh_`
+        //                     secret (a re-run). Keep it; do NOT overwrite from
+        //                     the stack-wide fallback, which is a DIFFERENT
+        //                     workspace's secret once >1 is installed. This is
+        //                     the #611 clobber fix — the stack-wide value is NOT
+        //                     necessarily this workspace's.
+        //   • mirror-stackwide — no per-workspace secret yet but stack-wide is
+        //                     set: mirror it (correct for the first/only
+        //                     workspace; warn for an additional one).
+        //   • prompt        — nothing to go on: ask for the signing secret.
+        // Rotation is not setup's job: use
+        // `bgagent linear update-webhook-secret <slug>` to rotate.
         const stackWideAlreadyConfigured = await isWebhookSecretConfigured(sm, webhookSecretArn!);
         let webhookSigningSecret: string | undefined;
 
@@ -759,9 +792,11 @@ export function makeLinearCommand(): Command {
           webhookSigningSecret = webhookSecret;
         }
 
-        // Mirror into the per-workspace OAuth secret so the receiver can
-        // look it up by orgId. Re-upsert with the merged payload.
-        if (webhookSigningSecret) {
+        // Mirror into the per-workspace OAuth secret so the receiver can look it
+        // up by orgId. In the PRESERVE case the secret is already in `stored`
+        // (folded above) and was written by the OAuth-secret upsert — no re-write
+        // needed. Only mirror-stackwide / prompt produce a NEW secret to persist.
+        if (webhookSigningSecret && webhookSigningSecret !== stored.webhook_signing_secret) {
           const merged: StoredLinearOauthToken = {
             ...stored,
             webhook_signing_secret: webhookSigningSecret,

--- a/cli/src/commands/linear.ts
+++ b/cli/src/commands/linear.ts
@@ -43,6 +43,7 @@ import {
   generatePkce,
   LINEAR_OAUTH_SECRET_PREFIX,
   linearOauthSecretName,
+  resolveWebhookSecretAction,
   StoredLinearOauthToken,
 } from '../linear-oauth';
 import { awaitOauthCallback, CALLBACK_URL } from '../oauth-callback-server';
@@ -601,6 +602,25 @@ export function makeLinearCommand(): Command {
         process.stdout.write('  → Storing OAuth token...');
         const sm = new SecretsManagerClient({ region });
         const now = new Date().toISOString();
+        // Preserve any EXISTING per-workspace webhook signing secret before the
+        // OAuth overwrite below. Re-running `setup` on an already-installed
+        // workspace must NOT clobber its working signing secret with the
+        // stack-wide fallback (which belongs to whichever workspace installed
+        // first) — that silently breaks signature verification (401 "Invalid
+        // signature") for every workspace after the first in a multi-workspace
+        // deployment. Rotation stays the job of `update-webhook-secret`.
+        let existingWebhookSecret: string | undefined;
+        try {
+          const prior = await sm.send(new GetSecretValueCommand({ SecretId: linearOauthSecretName(slug) }));
+          if (prior.SecretString) {
+            const priorBundle = JSON.parse(prior.SecretString) as Partial<StoredLinearOauthToken>;
+            if (priorBundle.webhook_signing_secret?.startsWith('lin_wh_')) {
+              existingWebhookSecret = priorBundle.webhook_signing_secret;
+            }
+          }
+        } catch {
+          // No prior bundle (first install) — nothing to preserve.
+        }
         const stored: StoredLinearOauthToken = {
           access_token: tokenResponse.access_token,
           refresh_token: tokenResponse.refresh_token ?? '',
@@ -687,8 +707,22 @@ export function makeLinearCommand(): Command {
         const stackWideAlreadyConfigured = await isWebhookSecretConfigured(sm, webhookSecretArn!);
         let webhookSigningSecret: string | undefined;
 
-        if (stackWideAlreadyConfigured) {
-          console.log('  ✓ Webhook signing secret already configured stack-wide (mirroring to per-workspace)');
+        const secretAction = resolveWebhookSecretAction(existingWebhookSecret, stackWideAlreadyConfigured);
+        if (secretAction.kind === 'preserve') {
+          // This workspace already had its own signing secret — keep it. Do NOT
+          // overwrite from the stack-wide fallback (a DIFFERENT workspace's
+          // secret once >1 is installed). Re-run case; rotation is
+          // `update-webhook-secret`'s job, not setup's.
+          console.log('  ✓ Preserving this workspace\'s existing webhook signing secret (re-run — not overwriting)');
+          webhookSigningSecret = secretAction.secret;
+        } else if (secretAction.kind === 'mirror-stackwide') {
+          // No per-workspace secret yet, but the stack-wide one is set. Safe to
+          // mirror ONLY when this is the first/only workspace — for a genuinely
+          // new ADDITIONAL workspace the stack-wide secret is the wrong one, so
+          // warn that the operator should verify (or run `update-webhook-secret`).
+          console.log('  ✓ No per-workspace secret yet; mirroring the stack-wide signing secret');
+          console.log('    (if this is an ADDITIONAL workspace, its Linear webhook secret differs —');
+          console.log(`     run \`bgagent linear update-webhook-secret ${slug}\` with this workspace's secret.)`);
           try {
             const value = await sm.send(new GetSecretValueCommand({ SecretId: webhookSecretArn! }));
             if (value.SecretString && value.SecretString.startsWith('lin_wh_')) {

--- a/cli/src/linear-oauth.ts
+++ b/cli/src/linear-oauth.ts
@@ -293,3 +293,45 @@ function isLinearTokenResponse(value: unknown): value is LinearTokenResponse {
 export function computeExpiresAt(expiresInSeconds: number, now: Date = new Date()): string {
   return new Date(now.getTime() + expiresInSeconds * 1000).toISOString();
 }
+
+/** What `bgagent linear setup` should do about the webhook signing secret. */
+export type WebhookSecretAction =
+  /** This workspace already has its own signing secret — keep it (re-run). */
+  | { readonly kind: 'preserve'; readonly secret: string }
+  /** No per-workspace secret; mirror the stack-wide one (safe for the first
+   *  workspace, ambiguous for an additional one — caller should warn). */
+  | { readonly kind: 'mirror-stackwide' }
+  /** No secret anywhere — prompt the operator for it (first install). */
+  | { readonly kind: 'prompt' };
+
+/**
+ * Decide which webhook signing secret `setup` should use, WITHOUT clobbering a
+ * working per-workspace secret.
+ *
+ * The bug this fixes: re-running `setup` on an already-installed workspace used
+ * to lift the *stack-wide* signing secret into the per-workspace bundle. That's
+ * correct only for the FIRST workspace — the stack-wide secret belongs to
+ * whichever workspace installed first, so for any additional workspace it
+ * overwrites the correct per-workspace secret with the wrong one, silently
+ * breaking signature verification (webhook 401 "Invalid signature").
+ *
+ * Rule: an existing valid per-workspace secret always wins (rotation is
+ * `update-webhook-secret`'s job); else mirror the stack-wide secret if present;
+ * else prompt. Pure — the caller supplies what it read from Secrets Manager.
+ *
+ * @param existingPerWorkspaceSecret the `webhook_signing_secret` on this
+ *        workspace's OAuth bundle BEFORE the setup rewrite (undefined if none).
+ * @param stackWideConfigured whether the stack-wide fallback secret is set.
+ */
+export function resolveWebhookSecretAction(
+  existingPerWorkspaceSecret: string | undefined,
+  stackWideConfigured: boolean,
+): WebhookSecretAction {
+  if (existingPerWorkspaceSecret?.startsWith('lin_wh_')) {
+    return { kind: 'preserve', secret: existingPerWorkspaceSecret };
+  }
+  if (stackWideConfigured) {
+    return { kind: 'mirror-stackwide' };
+  }
+  return { kind: 'prompt' };
+}

--- a/cli/src/linear-oauth.ts
+++ b/cli/src/linear-oauth.ts
@@ -335,3 +335,46 @@ export function resolveWebhookSecretAction(
   }
   return { kind: 'prompt' };
 }
+
+/**
+ * Read this workspace's EXISTING `webhook_signing_secret` before `setup`
+ * overwrites the OAuth bundle — FAIL CLOSED (#612 review B1).
+ *
+ * `fetchSecretString` fetches the prior per-workspace OAuth `SecretString`
+ * (typically a `SecretsManagerClient.send(GetSecretValueCommand)` wrapper). The
+ * value fed to {@link resolveWebhookSecretAction} decides whether the existing
+ * secret is preserved or the stack-wide one is mirrored over it — so a wrong
+ * `undefined` here re-arms the #611 clobber. Therefore:
+ *
+ *   • secret missing (`ResourceNotFoundException`) → genuine first install,
+ *     return undefined (nothing to preserve).
+ *   • secret present with a valid `lin_wh_…` `webhook_signing_secret` → return it.
+ *   • secret present but no/malformed secret → return undefined (nothing valid
+ *     to preserve; the caller mirrors/prompts).
+ *   • ANY OTHER error (AccessDenied, KMSAccessDenied, Throttling, network, or a
+ *     corrupt-JSON bundle) → THROW. Swallowing it would leave undefined and
+ *     silently clobber a working secret behind a green "Setup complete".
+ *
+ * `isNotFound` classifies the fetch error; callers pass an
+ * `name === 'ResourceNotFoundException'` check. On a throw the caller re-raises
+ * a CliError with an IAM/KMS hint (mirroring `isWebhookSecretConfigured`).
+ */
+export async function readExistingWebhookSecret(
+  fetchSecretString: () => Promise<string | undefined>,
+  isNotFound: (err: unknown) => boolean,
+): Promise<string | undefined> {
+  let raw: string | undefined;
+  try {
+    raw = await fetchSecretString();
+  } catch (err) {
+    if (isNotFound(err)) return undefined; // genuine first install
+    throw err; // fail closed — caller wraps with an actionable CliError
+  }
+  if (!raw) return undefined;
+  // A corrupt-but-present bundle must surface (JSON.parse throws → propagates),
+  // NOT silently become "nothing to preserve" → mirror-stackwide.
+  const bundle = JSON.parse(raw) as Partial<StoredLinearOauthToken>;
+  return bundle.webhook_signing_secret?.startsWith('lin_wh_')
+    ? bundle.webhook_signing_secret
+    : undefined;
+}

--- a/cli/test/commands/linear-setup-webhook.test.ts
+++ b/cli/test/commands/linear-setup-webhook.test.ts
@@ -1,0 +1,261 @@
+/**
+ *  MIT No Attribution
+ *
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy of
+ *  the Software without restriction, including without limitation the rights to
+ *  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ *  the Software, and to permit persons to whom the Software is furnished to do so.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+// #612 review B2 (issue #611 AC#3): end-to-end `linear setup` regression test
+// for the SECOND-WORKSPACE RE-RUN case. The pure decision
+// (`resolveWebhookSecretAction`) and the fail-closed pre-read
+// (`readExistingWebhookSecret`) are unit-tested in linear-oauth.test.ts; this
+// file closes the remaining gap by driving the `setup` ACTION through
+// `parseAsync` (with a mocked OAuth flow) and asserting the FINAL per-workspace
+// `PutSecretValue` payload — i.e. a re-run keeps THIS workspace's `lin_wh_`
+// secret and never clobbers it with the stack-wide (other workspace's) one.
+// Covers linear.ts's secretAction branch + mirror-back guard.
+import {
+  CreateSecretCommand,
+  GetSecretValueCommand,
+  PutSecretValueCommand,
+  ResourceExistsException,
+  ResourceNotFoundException,
+} from '@aws-sdk/client-secrets-manager';
+import { PutCommand } from '@aws-sdk/lib-dynamodb';
+import { makeLinearCommand } from '../../src/commands/linear';
+import * as configMod from '../../src/config';
+
+// ─── Mocks: external I/O the setup wizard touches before the secret logic ───
+
+// OAuth callback server — never bind a real localhost socket. Resolves with the
+// SAME `state` the wizard generated: we capture it from the authorization URL
+// the wizard prints under --no-browser (see captureState below).
+let capturedState = '';
+// Resolve LAZILY: the wizard starts this promise (linear.ts) BEFORE it prints
+// the authorization URL we scrape `state` from, so read capturedState after a
+// macrotask — by which point the synchronous URL print has run.
+const awaitOauthCallbackMock = jest.fn(
+  () =>
+    new Promise((resolve) =>
+      setTimeout(
+        () => resolve({ kind: 'direct-oauth' as const, code: 'auth-code', state: capturedState }),
+        0,
+      ),
+    ),
+);
+jest.mock('../../src/oauth-callback-server', () => ({
+  awaitOauthCallback: (...args: unknown[]) => awaitOauthCallbackMock(...args),
+  CALLBACK_URL: 'http://localhost:8080/oauth/callback',
+}));
+
+// linear-oauth: PARTIAL mock — keep the real code under test
+// (readExistingWebhookSecret + resolveWebhookSecretAction + name/expiry/PKCE/URL
+// helpers), stub only the network OAuth-code exchange.
+const exchangeAuthorizationCodeMock = jest.fn();
+jest.mock('../../src/linear-oauth', () => {
+  const actual = jest.requireActual('../../src/linear-oauth');
+  return {
+    ...actual,
+    exchangeAuthorizationCode: (...args: unknown[]) => exchangeAuthorizationCodeMock(...args),
+  };
+});
+
+const smSend = jest.fn();
+jest.mock('@aws-sdk/client-secrets-manager', () => {
+  const actual = jest.requireActual('@aws-sdk/client-secrets-manager');
+  return { ...actual, SecretsManagerClient: jest.fn(() => ({ send: smSend })) };
+});
+
+const cfnSend = jest.fn();
+jest.mock('@aws-sdk/client-cloudformation', () => {
+  const actual = jest.requireActual('@aws-sdk/client-cloudformation');
+  return { ...actual, CloudFormationClient: jest.fn(() => ({ send: cfnSend })) };
+});
+
+const ddbSend = jest.fn();
+jest.mock('@aws-sdk/lib-dynamodb', () => {
+  const actual = jest.requireActual('@aws-sdk/lib-dynamodb');
+  return {
+    ...actual,
+    DynamoDBDocumentClient: { from: jest.fn(() => ({ send: ddbSend })) },
+  };
+});
+jest.mock('@aws-sdk/client-dynamodb', () => {
+  const actual = jest.requireActual('@aws-sdk/client-dynamodb');
+  return { ...actual, DynamoDBClient: jest.fn(() => ({})) };
+});
+
+// A syntactically-valid id_token whose payload carries a `sub` claim, so
+// extractCognitoSub() (JWT base64url decode) resolves without real creds.
+const FAKE_ID_TOKEN = `x.${Buffer.from(JSON.stringify({ sub: 'sub-abc' })).toString('base64url')}.y`;
+
+const WEBHOOK_ARN = 'arn:aws:secretsmanager:us-west-2:111122223333:secret:LinearWebhookSecret-abc';
+const PER_WORKSPACE_NAME = 'bgagent-linear-oauth-demo';
+const THIS_WS_SECRET = 'lin_wh_thisWorkspace';
+const OTHER_WS_SECRET = 'lin_wh_otherWorkspace';
+
+/** The prior per-workspace OAuth bundle for `demo` — already carries ITS OWN
+ *  webhook signing secret (the value a re-run must preserve, not clobber). */
+function priorWorkspaceBundle(): string {
+  return JSON.stringify({
+    access_token: 'old-access',
+    refresh_token: 'old-refresh',
+    expires_at: '2026-06-17T01:00:00.000Z',
+    scope: 'read write',
+    client_id: 'client-id',
+    client_secret: 'client-secret',
+    workspace_id: 'org-demo',
+    workspace_slug: 'demo',
+    installed_at: '2026-06-01T00:00:00.000Z',
+    updated_at: '2026-06-01T00:00:00.000Z',
+    installed_by_platform_user_id: 'sub-abc',
+    webhook_signing_secret: THIS_WS_SECRET,
+  });
+}
+
+describe('linear setup — second-workspace re-run preserves the per-workspace webhook secret (#611/#612 B2)', () => {
+  let fetchMock: jest.Mock;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    capturedState = '';
+    awaitOauthCallbackMock.mockClear();
+    exchangeAuthorizationCodeMock.mockReset();
+    smSend.mockReset();
+    cfnSend.mockReset();
+    ddbSend.mockReset();
+
+    cfnSend.mockResolvedValue({
+      Stacks: [{
+        Outputs: [
+          { OutputKey: 'LinearWorkspaceRegistryTableName', OutputValue: 'registry-table' },
+          { OutputKey: 'LinearUserMappingTableName', OutputValue: 'user-mapping-table' },
+          { OutputKey: 'LinearWebhookSecretArn', OutputValue: WEBHOOK_ARN },
+        ],
+      }],
+    });
+
+    exchangeAuthorizationCodeMock.mockResolvedValue({
+      access_token: 'new-access',
+      refresh_token: 'new-refresh',
+      expires_in: 3600,
+      scope: 'read write',
+    });
+
+    // Linear GraphQL (identity + team keys + self-link picker) all go through
+    // fetch — benign viewer/org, empty team + member lists.
+    fetchMock = jest.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: {
+          viewer: { id: 'viewer-1', name: 'Admin', email: 'admin@demo.test' },
+          organization: { id: 'org-demo', name: 'Demo', urlKey: 'demo' },
+          teams: { nodes: [] },
+          users: { nodes: [] },
+        },
+      }),
+    }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    ddbSend.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test('the final per-workspace PutSecretValue keeps THIS workspace secret, not the stack-wide other', async () => {
+    // SM.send routing by command + target:
+    //  1. pre-read GetSecretValue(per-workspace bundle) → prior bundle carrying
+    //     lin_wh_thisWorkspace (the value a re-run must preserve).
+    //  2. upsertOauthSecret: CreateSecret → ResourceExists → PutSecretValue
+    //     (per-workspace) ← the write we assert.
+    //  3. isWebhookSecretConfigured GetSecretValue(stack-wide ARN) → lin_wh_other
+    //     (a DIFFERENT workspace's secret — the clobber source #611 lifted in).
+    smSend.mockImplementation((cmd: unknown) => {
+      if (cmd instanceof GetSecretValueCommand) {
+        const id = cmd.input.SecretId;
+        if (id === PER_WORKSPACE_NAME) return Promise.resolve({ SecretString: priorWorkspaceBundle() });
+        if (id === WEBHOOK_ARN) return Promise.resolve({ SecretString: OTHER_WS_SECRET });
+        return Promise.reject(new ResourceNotFoundException({ message: 'no', $metadata: {} }));
+      }
+      if (cmd instanceof CreateSecretCommand) {
+        return Promise.reject(new ResourceExistsException({ message: 'exists', $metadata: {} }));
+      }
+      if (cmd instanceof PutSecretValueCommand) {
+        return Promise.resolve({ ARN: `arn:${cmd.input.SecretId}` });
+      }
+      return Promise.resolve({});
+    });
+
+    const cfgSpy = jest.spyOn(configMod, 'loadConfig').mockReturnValue(
+      { region: 'us-west-2', api_url: 'https://api.example.test' } as ReturnType<typeof configMod.loadConfig>,
+    );
+    const credSpy = jest.spyOn(configMod, 'loadCredentials').mockReturnValue(
+      { id_token: FAKE_ID_TOKEN } as ReturnType<typeof configMod.loadCredentials>,
+    );
+    // Under --no-browser the wizard prints the authorization URL (which carries
+    // ?state=…). Capture it so awaitOauthCallback echoes the SAME state and the
+    // wizard's state check passes.
+    const logSpy = jest.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      const line = args.map(String).join(' ');
+      const m = line.match(/[?&]state=([^&\s]+)/);
+      if (m) capturedState = decodeURIComponent(m[1]);
+    });
+    try {
+      const program = makeLinearCommand();
+      await program.parseAsync([
+        'node', 'bgagent', 'setup', 'demo',
+        '--client-id', 'cid', '--client-secret', 'csecret', '--no-browser',
+      ]);
+    } finally {
+      cfgSpy.mockRestore();
+      credSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+
+    // Sanity: the wizard actually reached the OAuth callback (state captured).
+    expect(capturedState).not.toBe('');
+    expect(awaitOauthCallbackMock).toHaveBeenCalled();
+
+    // Every per-workspace PutSecretValue payload must carry THIS workspace's
+    // secret and NEVER the stack-wide other's — the #611 clobber regression.
+    const perWsPuts = smSend.mock.calls
+      .map((c) => c[0])
+      .filter((cmd): cmd is InstanceType<typeof PutSecretValueCommand> =>
+        cmd instanceof PutSecretValueCommand && cmd.input.SecretId === PER_WORKSPACE_NAME);
+
+    expect(perWsPuts.length).toBeGreaterThanOrEqual(1);
+    for (const put of perWsPuts) {
+      const bundle = JSON.parse(String(put.input.SecretString)) as { webhook_signing_secret?: string };
+      expect(bundle.webhook_signing_secret).toBe(THIS_WS_SECRET);
+      expect(bundle.webhook_signing_secret).not.toBe(OTHER_WS_SECRET);
+    }
+
+    // The stack-wide ARN is never overwritten by setup (rotation is
+    // update-webhook-secret's job) — no PutSecretValue targets it.
+    const stackWidePuts = smSend.mock.calls
+      .map((c) => c[0])
+      .filter((cmd) => cmd instanceof PutSecretValueCommand && cmd.input.SecretId === WEBHOOK_ARN);
+    expect(stackWidePuts).toHaveLength(0);
+
+    // The registry row was still written (setup completed end-to-end).
+    const registryPut = ddbSend.mock.calls
+      .map((c) => c[0])
+      .find((cmd) => cmd instanceof PutCommand && cmd.input.TableName === 'registry-table');
+    expect(registryPut).toBeDefined();
+  });
+});

--- a/cli/test/linear-oauth.test.ts
+++ b/cli/test/linear-oauth.test.ts
@@ -28,6 +28,7 @@ import {
   LINEAR_OAUTH_SCOPES,
   LINEAR_TOKEN_ENDPOINT,
   linearOauthSecretName,
+  readExistingWebhookSecret,
   refreshAccessToken,
   resolveWebhookSecretAction,
 } from '../src/linear-oauth';
@@ -312,5 +313,55 @@ describe('resolveWebhookSecretAction', () => {
     // A corrupt/empty value must not be "preserved" as if valid.
     expect(resolveWebhookSecretAction('garbage', true)).toEqual({ kind: 'mirror-stackwide' });
     expect(resolveWebhookSecretAction('', false)).toEqual({ kind: 'prompt' });
+  });
+});
+
+describe('readExistingWebhookSecret — fail-closed pre-read (#612 review B1/B2)', () => {
+  const notFound = (err: unknown) => (err as { name?: string }).name === 'ResourceNotFoundException';
+  const bundle = (secret?: string) =>
+    JSON.stringify({ access_token: 'a', webhook_signing_secret: secret });
+
+  it('returns the existing lin_wh_ secret when the bundle has one (→ preserve, not clobber)', async () => {
+    const got = await readExistingWebhookSecret(async () => bundle('lin_wh_thisWorkspace'), notFound);
+    // This is the value that makes resolveWebhookSecretAction PRESERVE — the fix.
+    expect(got).toBe('lin_wh_thisWorkspace');
+    expect(resolveWebhookSecretAction(got, true)).toEqual({ kind: 'preserve', secret: 'lin_wh_thisWorkspace' });
+  });
+
+  it('returns undefined on ResourceNotFoundException (genuine first install)', async () => {
+    const got = await readExistingWebhookSecret(async () => {
+      throw Object.assign(new Error('no'), { name: 'ResourceNotFoundException' });
+    }, notFound);
+    expect(got).toBeUndefined();
+  });
+
+  it('returns undefined when the bundle exists but has no/malformed secret', async () => {
+    expect(await readExistingWebhookSecret(async () => bundle(undefined), notFound)).toBeUndefined();
+    expect(await readExistingWebhookSecret(async () => bundle('not-a-wh'), notFound)).toBeUndefined();
+    expect(await readExistingWebhookSecret(async () => undefined, notFound)).toBeUndefined();
+  });
+
+  it('THROWS (fails closed) on AccessDenied — must NOT default to undefined and clobber', async () => {
+    // The B1 bug: a bare catch here would return undefined → mirror-stackwide →
+    // the #611 clobber, silently. The pre-read must surface the error instead.
+    const accessDenied = Object.assign(new Error('denied'), { name: 'AccessDeniedException' });
+    await expect(
+      readExistingWebhookSecret(async () => { throw accessDenied; }, notFound),
+    ).rejects.toBe(accessDenied);
+  });
+
+  it('THROWS on KMSAccessDeniedException / Throttling / network (any non-not-found)', async () => {
+    for (const name of ['KMSAccessDeniedException', 'ThrottlingException', 'InternalServiceError']) {
+      const err = Object.assign(new Error(name), { name });
+      await expect(
+        readExistingWebhookSecret(async () => { throw err; }, notFound),
+      ).rejects.toBe(err);
+    }
+  });
+
+  it('THROWS on a corrupt-but-present bundle (JSON.parse) — not silently "nothing to preserve"', async () => {
+    await expect(
+      readExistingWebhookSecret(async () => '{not valid json', notFound),
+    ).rejects.toThrow();
   });
 });

--- a/cli/test/linear-oauth.test.ts
+++ b/cli/test/linear-oauth.test.ts
@@ -29,6 +29,7 @@ import {
   LINEAR_TOKEN_ENDPOINT,
   linearOauthSecretName,
   refreshAccessToken,
+  resolveWebhookSecretAction,
 } from '../src/linear-oauth';
 
 describe('linearOauthSecretName', () => {
@@ -279,5 +280,37 @@ describe('refreshAccessToken', () => {
       clientSecret: 'csec',
       fetchImpl: fetchImpl as unknown as typeof fetch,
     })).rejects.toThrow(CliError);
+  });
+});
+
+describe('resolveWebhookSecretAction', () => {
+  it('PRESERVES an existing per-workspace secret over the stack-wide one (multi-workspace re-run — the bug)', () => {
+    // The regression: re-running `setup` on an already-installed workspace must
+    // NOT overwrite its working signing secret with the stack-wide fallback
+    // (which belongs to a different workspace once >1 is installed) — that
+    // silently breaks signature verification (webhook 401 "Invalid signature").
+    const action = resolveWebhookSecretAction('lin_wh_thisWorkspace', true);
+    expect(action).toEqual({ kind: 'preserve', secret: 'lin_wh_thisWorkspace' });
+  });
+
+  it('preserves the existing secret even when no stack-wide secret is set', () => {
+    expect(resolveWebhookSecretAction('lin_wh_existing', false)).toEqual({
+      kind: 'preserve',
+      secret: 'lin_wh_existing',
+    });
+  });
+
+  it('mirrors the stack-wide secret when there is no per-workspace one yet (first workspace)', () => {
+    expect(resolveWebhookSecretAction(undefined, true)).toEqual({ kind: 'mirror-stackwide' });
+  });
+
+  it('prompts when neither a per-workspace nor a stack-wide secret exists (first install)', () => {
+    expect(resolveWebhookSecretAction(undefined, false)).toEqual({ kind: 'prompt' });
+  });
+
+  it('ignores a malformed existing secret (not lin_wh_) and falls through', () => {
+    // A corrupt/empty value must not be "preserved" as if valid.
+    expect(resolveWebhookSecretAction('garbage', true)).toEqual({ kind: 'mirror-stackwide' });
+    expect(resolveWebhookSecretAction('', false)).toEqual({ kind: 'prompt' });
   });
 });


### PR DESCRIPTION
## Summary
Fixes #611. Re-running `bgagent linear setup <slug>` on an already-installed workspace overwrote its per-workspace webhook signing secret with the stack-wide fallback (a *different* workspace's secret once >1 is installed) → webhook 401 `{"error":"Invalid signature"}` for every workspace after the first. Live-hit on `demo-abca` after a token re-auth; recovery required `update-webhook-secret`.

## Fix
- New pure helper `resolveWebhookSecretAction()` (`cli/src/linear-oauth.ts`): `preserve | mirror-stackwide | prompt`. An existing valid per-workspace secret always wins; else mirror stack-wide (warn for additional workspaces); else prompt.
- `setup` reads the existing per-workspace secret before the OAuth overwrite and preserves it.
- 5 unit tests incl. the multi-workspace re-run regression.

## Governance
Approved issue **#611**, conforming branch `fix/611-…`.

## Test
cli build green — 610 tests (compile + eslint clean).