### PR TITLE
fix(agent): re-run install.cjs after npm update in Dockerfile

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -55,7 +55,8 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
 RUN npm install -g npm@latest && \
     npm install -g @anthropic-ai/claude-code@2.1.191 && \
     CLAUDE_NPM_ROOT="$(npm root -g)/@anthropic-ai/claude-code" && \
-    npm --prefix "${CLAUDE_NPM_ROOT}" update tar minimatch glob cross-spawn picomatch
+    npm --prefix "${CLAUDE_NPM_ROOT}" update tar minimatch glob cross-spawn picomatch && \
+    node "${CLAUDE_NPM_ROOT}/install.cjs"
 
 # Install uv (fast Python package manager) — pinned for reproducibility
 COPY --from=ghcr.io/astral-sh/uv:0.11.14 /uv /usr/local/bin/uv


### PR DESCRIPTION
## Summary

- Claude Code 2.1.x ships as a native binary installed via a postinstall script (`install.cjs`) that hardlinks the platform-specific binary over a placeholder stub at `bin/claude.exe`.
- In the agent Dockerfile, the `npm --prefix update` step (which patches vulnerable transitive deps inside the global `@anthropic-ai/claude-code` install) re-extracts the package's bin entry, overwriting the native binary with the stub script. npm does not re-run postinstall during `update`, so the binary is never restored.
- At runtime in AgentCore, the container tries to exec the stub (a shell script, not an ELF binary), producing: `OSError: [Errno 8] Exec format error: 'claude'`
- Fix: append `node "${CLAUDE_NPM_ROOT}/install.cjs"` to the Dockerfile's npm install layer so the native binary is re-placed after the update step.

## Test plan

- [x] Built image locally and verified `claude --version` returns `2.1.191 (Claude Code)`
- [x] Deployed to `backgroundagent-dev` stack in us-west-2
- [x] Submitted a task and confirmed it completes without exec format error