### PR TITLE
fix(deps): bump astro to 7.1.3 + re-resolve brace-expansion to clear osv-scanner (#636)

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.9",
     "@astrojs/starlight": "^0.41.2",
-    "astro": "7.0.5",
+    "astro": "7.1.3",
     "remark-gfm": "^4.0.1",
     "typescript": "^6.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,74 +12,74 @@
     kleur "^4.1.5"
     yargs "^17.7.2"
 
-"@astrojs/compiler-binding-darwin-arm64@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.3.0.tgz#a76ad32be574ef25a728f50af2791a2ebcfa3b4b"
-  integrity sha512-3n0uu+uJpnCq8b4JFi3uGDsIisAvHctxSmH+cIO9Gbei1H1Y1QXaYboXyiWJugUmprr3OEYP7+LdodzpVFzLMQ==
+"@astrojs/compiler-binding-darwin-arm64@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding-darwin-arm64/-/compiler-binding-darwin-arm64-0.3.1.tgz#92209f00ee053691d0b8369d7f05b9d64969f957"
+  integrity sha512-IEmEF2fUIlTHtpeE/isyEGVOB14cEyh/LZOFYt6wn3jNyVpdC8aR5OZ+RzFUR/f+8ZDM1LaMwZKvoA7eMyJeFw==
 
-"@astrojs/compiler-binding-darwin-x64@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.3.0.tgz#473f8216c7450315f6a038c2dadb771437f6cda0"
-  integrity sha512-scxNGKjOBydMo1QR4LtK0FMgh7ubQomJDv953nz2msQFkPKke/0FpPv/cQM0T/kuZdReZQFU8Oz3iOrP/6WHEg==
+"@astrojs/compiler-binding-darwin-x64@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding-darwin-x64/-/compiler-binding-darwin-x64-0.3.1.tgz#b42328d009d935e13555031361474ecaaef35d79"
+  integrity sha512-GF2kIxjpPDLsn94zbZNMsxEmkU828QqnmM7kiQJnaooS3jmI+I7kk6+oI6EpwOsK3femCMdcm+wmOsEqtGrmjQ==
 
-"@astrojs/compiler-binding-linux-arm64-gnu@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.3.0.tgz#232987dbc452730e69b6aea52372522d895adc2a"
-  integrity sha512-NZrWLolVUANmrnl0zrFK/Sx5Sock1gEUT49ALfMTTCA5Ya2ec/BoJXMIg4KgE+wZcrdXJ8e+WyEhM7YLk/FJkA==
+"@astrojs/compiler-binding-linux-arm64-gnu@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding-linux-arm64-gnu/-/compiler-binding-linux-arm64-gnu-0.3.1.tgz#31454d63ed3135db50a29f0ec9ee1a59b38db6a7"
+  integrity sha512-XJL3SDmOtVrqFhCirNcHwE91+IesJqlgNo23I4qW9QUYfwzm/TBZuH61fgqsb1ttgR1mMYz6ooPWs0JDhwMqpQ==
 
-"@astrojs/compiler-binding-linux-arm64-musl@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.3.0.tgz#64dfe7910ce22936ddf8aabbeab17e57ced5c176"
-  integrity sha512-PjwRmKgMFDsFhg82g0poXlIY8Qn3fMA3hXjaR0coJWJzTJsRH9ATU0j2ocigjtU1h3vL/yR7yLUxGj/lTCq73g==
+"@astrojs/compiler-binding-linux-arm64-musl@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding-linux-arm64-musl/-/compiler-binding-linux-arm64-musl-0.3.1.tgz#87c12c470bd1320232232b294a89b69841851bcd"
+  integrity sha512-xqE8BVbDoBueK/B47w30PtkVofUWJKGkwoMVE+EOMLf11rnoANxIAdA9FPqY+rng4oNI5ndHGsri1yPj2k8vZQ==
 
-"@astrojs/compiler-binding-linux-x64-gnu@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.3.0.tgz#201de3590b8f4a09939ddc309d08843f2d5a8c15"
-  integrity sha512-Dr69VJYlnSfyL8gzELW6S4mE41P7TDPn1IKjwMnjdZ7+dxgJI50oMLFSk1LVe26bHmWB3ktuh8fDVK1THI9e9A==
+"@astrojs/compiler-binding-linux-x64-gnu@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding-linux-x64-gnu/-/compiler-binding-linux-x64-gnu-0.3.1.tgz#7cea5d733f319937c5ab1d9c49fd993a78089023"
+  integrity sha512-1y0StU1qiCuDFH3rmbRJXcxdfHxFPrES1Rd+RLffosvUR7I2cH5SF5SFnBN9vXpzpkmyElZm3Yr47iJBPN7vVA==
 
-"@astrojs/compiler-binding-linux-x64-musl@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.3.0.tgz#dca8e34597f8cb8ea2e04929789b24891926a889"
-  integrity sha512-AEt+bRw8PfImCcyRH1lpXVB8CdmQ1K/wPo5u99iec4/U/XdNvQZ715YVuNzIJpbJXelgQeZ5H2+Ea7XwRyWY5g==
+"@astrojs/compiler-binding-linux-x64-musl@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding-linux-x64-musl/-/compiler-binding-linux-x64-musl-0.3.1.tgz#09d58e1fbce2fc2fefa2f296419cf18468b513f9"
+  integrity sha512-16q0fYf7kpbmdObZEeZJEup8hQv/whgNwVjrSvT8umrKwLDSnNIWiQpm09lQQu6bweZB0XyIvHwlPitvJhC+hg==
 
-"@astrojs/compiler-binding-wasm32-wasi@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.3.0.tgz#6826d9d4a4a3e2b80040e27c612692e6afbb01aa"
-  integrity sha512-U80tA1j8V6LjhiTZzVCtG4E8hrNVVNXDGV5fCgJ94q8FU9CPH+XwdDDhLzBybfWhKfyItXmQiZNRPTiPCYTpVg==
+"@astrojs/compiler-binding-wasm32-wasi@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding-wasm32-wasi/-/compiler-binding-wasm32-wasi-0.3.1.tgz#f2df370782a2ac3152adc066ae5cb1a7377eb8c5"
+  integrity sha512-cB456shIwDv/PrVT+2QG7LFndpHkVge5HjqADKZgGaAc9JHVktCtjSrcdkRQ+3tbkPazNKaTLRjXLIiz2NIx9g==
   dependencies:
     "@napi-rs/wasm-runtime" "^1.1.6"
 
-"@astrojs/compiler-binding-win32-arm64-msvc@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.3.0.tgz#ee8195fefed54fc3199273a5ad5bd1776561a7ff"
-  integrity sha512-CpY1RII2r1XMpOUVD1VR/F2wtuRsiOCkFULS10Khyj8/DFZMtxVuUCAWGw+CW2Ka0h6eP3Xc1CA+glFlvXMPxA==
+"@astrojs/compiler-binding-win32-arm64-msvc@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding-win32-arm64-msvc/-/compiler-binding-win32-arm64-msvc-0.3.1.tgz#34f8bc472fc319f7e30613e09d94be6cf510d218"
+  integrity sha512-ur/9+If/yTE69mmeX5MqSZndL0HOyx67GeNZUy3N7wVdWpLz9UTJXwyWS4UR2PUQHitghjsM5xoX0Ge56WRVQQ==
 
-"@astrojs/compiler-binding-win32-x64-msvc@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.3.0.tgz#7fdd58ca7e02f4ae32f8506befea30a3b7230288"
-  integrity sha512-qmFbs769oeeGrRebAnCW7aBk8m71vf85W/dX/jddfx5Z06/w0wf7TZCfJPOX1Fld2t+4N+iXzfGEJG+zJQ+bzg==
+"@astrojs/compiler-binding-win32-x64-msvc@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding-win32-x64-msvc/-/compiler-binding-win32-x64-msvc-0.3.1.tgz#25e62bd699274be98bc0ccff5f8df337064a4a70"
+  integrity sha512-k0W+kDBzDkNZOqu4kElDvCOIbKw5Ut9S1WZ1Krj3KTgNuBERNKXsMMsRLLcbgfdMdbe7bTekQLshZrrvmYpmwA==
 
-"@astrojs/compiler-binding@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding/-/compiler-binding-0.3.0.tgz#b4f12e7458ef4f9afa6c7eda661be3eff0af49d4"
-  integrity sha512-zlsOT5COD9hRwplJCgQhS21unxON5AKirf0vgt1ijXwuseYIaZdm2ZOpF8fsz+DY9EyXx+I/ukxtg7uoBep68A==
+"@astrojs/compiler-binding@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@astrojs/compiler-binding/-/compiler-binding-0.3.1.tgz#37cbff55d19b90651a384dd015236a441b348aae"
+  integrity sha512-DaAUj29AIBU2XdJ8uwcab8lW5O2pk9pY8AXkcMw0sw77nVa3oeTYRcO+Dvbbpoexf6ThMc0FMWYCQ/wN1/T7oQ==
   optionalDependencies:
-    "@astrojs/compiler-binding-darwin-arm64" "0.3.0"
-    "@astrojs/compiler-binding-darwin-x64" "0.3.0"
-    "@astrojs/compiler-binding-linux-arm64-gnu" "0.3.0"
-    "@astrojs/compiler-binding-linux-arm64-musl" "0.3.0"
-    "@astrojs/compiler-binding-linux-x64-gnu" "0.3.0"
-    "@astrojs/compiler-binding-linux-x64-musl" "0.3.0"
-    "@astrojs/compiler-binding-wasm32-wasi" "0.3.0"
-    "@astrojs/compiler-binding-win32-arm64-msvc" "0.3.0"
-    "@astrojs/compiler-binding-win32-x64-msvc" "0.3.0"
+    "@astrojs/compiler-binding-darwin-arm64" "0.3.1"
+    "@astrojs/compiler-binding-darwin-x64" "0.3.1"
+    "@astrojs/compiler-binding-linux-arm64-gnu" "0.3.1"
+    "@astrojs/compiler-binding-linux-arm64-musl" "0.3.1"
+    "@astrojs/compiler-binding-linux-x64-gnu" "0.3.1"
+    "@astrojs/compiler-binding-linux-x64-musl" "0.3.1"
+    "@astrojs/compiler-binding-wasm32-wasi" "0.3.1"
+    "@astrojs/compiler-binding-win32-arm64-msvc" "0.3.1"
+    "@astrojs/compiler-binding-win32-x64-msvc" "0.3.1"
 
-"@astrojs/compiler-rs@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@astrojs/compiler-rs/-/compiler-rs-0.3.0.tgz#577a5bfa5ed07838b5d68f0ef369771b74a3d2fe"
-  integrity sha512-J2qEVHtIDjEM9TxwmwuebOGmZNwhKu/dR7P7qBpnJKGmBBX0vdweQ/4cEXhj8fBbWVUB5V12xWChri3CgKNULQ==
+"@astrojs/compiler-rs@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@astrojs/compiler-rs/-/compiler-rs-0.3.1.tgz#3d4aaa18faed72cfad5232f9a29f1ec2ef892359"
+  integrity sha512-aT7xkgsbNoS6nriY5qKpbihK43slFHO41iqgHCTdOvn1ifaQxLCc5yXy+6GzAtiafoaC1zA7OwVXCXMsvUZOkg==
   dependencies:
-    "@astrojs/compiler-binding" "0.3.0"
+    "@astrojs/compiler-binding" "0.3.1"
 
 "@astrojs/compiler@^2.13.1":
   version "2.13.1"
@@ -161,14 +161,15 @@
     unist-util-visit-parents "^6.0.2"
     vfile "^6.0.3"
 
-"@astrojs/markdown-satteri@0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@astrojs/markdown-satteri/-/markdown-satteri-0.3.2.tgz#413b03a9d1d816fd0f8727d0b1de307a9ff51165"
-  integrity sha512-feXuUPy41gVfeM7EHT1ciUim8ozGr+YHXab9uUBc1Hk8y60DQosO8ldL+AoPXnCAoGj1OChwHfvXmmJ6XVnY9A==
+"@astrojs/markdown-satteri@0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@astrojs/markdown-satteri/-/markdown-satteri-0.3.4.tgz#b1a8566a0b12c0a7d4cb3ac02d822f586eec822c"
+  integrity sha512-6Lvt/bQZEBW+zzdhPblvfZEy5PGEYJaUsUqaCgwHeRPxZJL1gc9I+DRLKWJjjYTWDzVUTzXlMq4WwSK+X34CVw==
   dependencies:
-    "@astrojs/internal-helpers" "0.10.0"
+    "@astrojs/internal-helpers" "0.10.1"
     "@astrojs/prism" "4.0.2"
     github-slugger "^2.0.0"
+    hast-util-from-html "^2.0.3"
     satteri "^0.9.1"
 
 "@astrojs/markdown-satteri@^0.3.2":
@@ -252,16 +253,15 @@
     unist-util-visit "^5.1.0"
     vfile "^6.0.3"
 
-"@astrojs/telemetry@3.3.2":
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/@astrojs/telemetry/-/telemetry-3.3.2.tgz#9174d444e120da70d966dfc976d9e37a3c09262d"
-  integrity sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==
+"@astrojs/telemetry@3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@astrojs/telemetry/-/telemetry-3.3.3.tgz#24e5bcf203d1ac07747c02e3f0710137272082b8"
+  integrity sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ==
   dependencies:
     ci-info "^4.4.0"
     dset "^3.1.4"
     is-docker "^4.0.0"
-    is-wsl "^3.1.1"
-    which-pm-runs "^1.1.0"
+    package-manager-detector "^1.6.0"
 
 "@astrojs/yaml2ts@^0.2.4":
   version "0.2.4"
@@ -3503,15 +3503,15 @@ astro-expressive-code@^0.44.0:
     rehype-expressive-code "^0.44.0"
     url-extras "^0.1.0"
 
-astro@7.0.5:
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/astro/-/astro-7.0.5.tgz#65cb2f38e7df20e461e4cd494f7c9de651e91936"
-  integrity sha512-KR/zBBgU6I+F5vDoTsuTbXbBmI565CToDOgPr0pPiL2Hgrvx4CV8Cg2wtT6VqqyOS7BIfBkdagKD+40SojGl7w==
+astro@7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/astro/-/astro-7.1.3.tgz#f80d8459c10fff08b2c457e9171547f32761582c"
+  integrity sha512-4dhPyAAXthf3xLEYnG8SeL7yr/nTPPABfY7e9YF0yuO+vK9Xp+8Q5j4xzsmL3GueukQv4oNwGNTBepLOiDGeJA==
   dependencies:
-    "@astrojs/compiler-rs" "^0.3.0"
-    "@astrojs/internal-helpers" "0.10.0"
-    "@astrojs/markdown-satteri" "0.3.2"
-    "@astrojs/telemetry" "3.3.2"
+    "@astrojs/compiler-rs" "^0.3.1"
+    "@astrojs/internal-helpers" "0.10.1"
+    "@astrojs/markdown-satteri" "0.3.4"
+    "@astrojs/telemetry" "3.3.3"
     "@capsizecss/unpack" "^4.0.0"
     "@clack/prompts" "^1.1.0"
     "@oslojs/encoding" "^1.1.0"
@@ -3522,7 +3522,7 @@ astro@7.0.5:
     ci-info "^4.4.0"
     clsx "^2.1.1"
     common-ancestor-path "^2.0.0"
-    cookie "^1.1.1"
+    cookie "^2.0.1"
     devalue "^5.8.1"
     diff "^8.0.3"
     dset "^3.1.4"
@@ -3539,7 +3539,7 @@ astro@7.0.5:
     magic-string "^0.30.21"
     magicast "^0.5.2"
     mrmime "^2.0.1"
-    neotraverse "^0.6.18"
+    neotraverse "^1.0.1"
     obug "^2.1.1"
     p-limit "^7.3.0"
     p-queue "^9.1.0"
@@ -3716,17 +3716,17 @@ bowser@^2.11.0:
   integrity sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==
 
 brace-expansion@^1.1.7:
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.15.tgz#a6d90d54067236e5f42570a3b7378d594d9b7738"
-  integrity sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==
+  version "1.1.16"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
+  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
 brace-expansion@^2.0.2:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.1.tgz#c68b1c4111c76aae3a6fba55d496cee10c39dad8"
-  integrity sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
+  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
   dependencies:
     balanced-match "^1.0.0"
 
@@ -3984,10 +3984,10 @@ cookie-es@^1.2.3:
   resolved "https://registry.yarnpkg.com/cookie-es/-/cookie-es-1.2.3.tgz#06ca3c5f5f3531684a2059666a361173f74a89c8"
   integrity sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==
 
-cookie@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.1.1.tgz#3bb9bdfc82369db9c2f69c93c9c3ceb310c88b3c"
-  integrity sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==
+cookie@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-2.0.1.tgz#1fc7e9bddf38fa9567cd4d750820087cdb5d6e98"
+  integrity sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==
 
 create-require@^1.1.0:
   version "1.1.1"
@@ -5323,11 +5323,6 @@ is-decimal@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-2.0.1.tgz#9469d2dc190d0214fd87d78b78caecc0cc14eef7"
   integrity sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==
 
-is-docker@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-3.0.0.tgz#90093aa3106277d8a77a5910dbae71747e15a200"
-  integrity sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==
-
 is-docker@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-4.0.0.tgz#6aab87c77a30ddff39c460af372ee1795aee7848"
@@ -5360,13 +5355,6 @@ is-hexadecimal@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz#86b5bf668fca307498d319dfc03289d781a90027"
   integrity sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==
 
-is-inside-container@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-inside-container/-/is-inside-container-1.0.0.tgz#e81fba699662eb31dbdaf26766a61d4814717ea4"
-  integrity sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==
-  dependencies:
-    is-docker "^3.0.0"
-
 is-plain-obj@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
@@ -5388,13 +5376,6 @@ is-unsafe@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-unsafe/-/is-unsafe-1.0.1.tgz#ce89b55dec0034364f5beda41e10481efa8fa317"
   integrity sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==
-
-is-wsl@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-3.1.1.tgz#327897b26832a3eb117da6c27492d04ca132594f"
-  integrity sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==
-  dependencies:
-    is-inside-container "^1.0.0"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -6875,10 +6856,10 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-neotraverse@^0.6.18:
-  version "0.6.18"
-  resolved "https://registry.yarnpkg.com/neotraverse/-/neotraverse-0.6.18.tgz#abcb33dda2e8e713cf6321b29405e822230cdb30"
-  integrity sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==
+neotraverse@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/neotraverse/-/neotraverse-1.0.1.tgz#7c89b43f6504ef85928c718f578c68621576d194"
+  integrity sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==
 
 netmask@^2.0.2:
   version "2.1.1"
@@ -8706,11 +8687,6 @@ whatwg-mimetype@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
   integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
-
-which-pm-runs@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/which-pm-runs/-/which-pm-runs-1.1.0.tgz#35ccf7b1a0fce87bd8b92a478c9d045785d3bf35"
-  integrity sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
## What & why

The `osv-scanner` required check (`Secrets, deps, and workflow scan` → `Dependency scan (osv-scanner)`)
fails on `main`'s `yarn.lock`, which **ejects every PR from the merge queue** — the `merge_group`
re-scan runs against the latest main and fails any queued PR. Observed on #623, which is otherwise
approved + CLEAN but kept getting removed from the queue by `github-merge-queue[bot]`.

These advisories were **published after** the affected PRs' PR-open scans, so PR-level checks are
green while the `merge_group` re-scan is red.

Closes #636.

## Changes (lockfile-only + one version string)

- **astro** `7.0.5` → **`7.1.3`** (`docs/package.json`). Fixes `GHSA-4g3v-8h47-v7g6` (reflected XSS),
  `GHSA-8mv7-9c27-98vc`, `GHSA-f48w-9m4c-m7f5`.
  - ⚠️ **Intentionally 7.1.3, not 7.1.0.** `GHSA-4g3v` lists its fix as `7.1.0`, and Dependabot
    **#631 / #630** bump to exactly that — but **`7.1.0` is flagged malicious** by
    [`MAL-2026-10726`](https://osv.dev/vulnerability/MAL-2026-10726) (published 2026-07-16, affects
    only 7.1.0). `7.1.3` is the current `latest` and is past the single poisoned release.
- **brace-expansion** re-resolved within the existing `^1.1.7` / `^2.0.2` ranges:
  `1.1.15 → 1.1.16` and `2.1.1 → 2.1.2` (`GHSA-3jxr-9vmj-r5cp`, CVSS 7.7). Transitive-only, so no
  `resolutions` pin was needed — the caret ranges already permit the patched versions.

## Verification

- `mise run security:deps` (osv-scanner, exact CI command) → **No issues found** (exit 0).
- `mise //docs:build` → 68 pages built clean under astro 7.1.3.
- `mise run security:retire` → clean.
- Range-scoped gitleaks (`origin/main..HEAD`) → no leaks (the pre-push full-history hit is
  pre-existing history on other branches, unrelated to this diff).

## Supersedes

Dependabot **#631** and **#630** (both bump astro to the malicious `7.1.0`) — close as superseded
once this lands.
