### PR TITLE
docs(aws-notes): add S3 bucket default quota note with source URL

### DIFF
--- a/docs/aws-notes.md
+++ b/docs/aws-notes.md
@@ -1,0 +1,7 @@
+# AWS Notes
+
+## S3 Buckets per Account — Default Maximum
+
+By default, AWS allows up to **10,000 general purpose S3 buckets per AWS account**. This quota can be increased by submitting a request through the [Service Quotas console](https://console.aws.amazon.com/servicequotas/home/services/s3/quotas/).
+
+**Source:** [Amazon S3 — Bucket quotas, limitations, and restrictions](https://docs.aws.amazon.com/AmazonS3/latest/userguide/BucketRestrictions.html)


### PR DESCRIPTION
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Task-Id: 01KYATG7RHK2X6QW3M1KA352PM
Prompt-Version: 1c9c10e027a2

<!-- Summarize the pull request -->

#### Area

<!-- Check all that apply -->

- [ ] `cdk` — infrastructure, handlers, constructs
- [ ] `agent` — Python runtime / Docker image
- [ ] `cli` — `bgagent` client
- [ ] `docs` — guides or design sources (`docs/guides/`, `docs/design/`)
- [ ] `tooling` — root `mise.toml`, scripts, CI workflows

Tip: [AGENTS.md](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/blob/main/AGENTS.md) lists where to edit and which tests to extend.

#### Related

<!-- Issue #, Vulnerability, References if available:* -->

#### Changes

<!-- Description of changes:* -->

#### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/blob/main/LICENSE).
