### PR TITLE
fix(deps): clear 4 osv-scanner advisories (brace-expansion, bedrock-agentcore)

### DIFF
--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     # try/except (ImportError, AttributeError), so removing this dep
     # would degrade gracefully — but for now we keep the dep to
     # preserve the clean code path.
-    "bedrock-agentcore==1.17.0", #https://pypi.org/project/bedrock-agentcore/
+    "bedrock-agentcore==1.18.1", #https://pypi.org/project/bedrock-agentcore/
     "claude-agent-sdk==0.2.110", #https://github.com/anthropics/claude-agent-sdk-python/releases/tag/v0.2.110 (bundles claude CLI 2.1.191; kept in lockstep with the npm CLI pin in the Dockerfile, #215)
     "requests==2.34.2", #https://pypi.org/project/requests/
     "fastapi==0.139.0", #https://pypi.org/project/fastapi/

--- a/agent/uv.lock
+++ b/agent/uv.lock
@@ -168,7 +168,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aws-opentelemetry-distro", specifier = "==0.18.0" },
-    { name = "bedrock-agentcore", specifier = "==1.17.0" },
+    { name = "bedrock-agentcore", specifier = "==1.18.1" },
     { name = "boto3", specifier = "==1.43.40" },
     { name = "cedarpy", specifier = "==4.8.4" },
     { name = "claude-agent-sdk", specifier = "==0.2.110" },
@@ -193,7 +193,7 @@ dev = [
 
 [[package]]
 name = "bedrock-agentcore"
-version = "1.17.0"
+version = "1.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -205,9 +205,9 @@ dependencies = [
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/ae/38e870cd7f73ba41ab78ca1fef9b40e0b8a486498e8978965ce65bde61f3/bedrock_agentcore-1.17.0.tar.gz", hash = "sha256:dc237d313ffd6b1fc5547ff334ed7aa160b469bc086b20f0f8679d18d75cf20d", size = 939469, upload-time = "2026-07-02T15:42:27.032Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/e8/8149bb168ef3825884685eb98ef868f5bb5f796e4ea58eb98e8df3248937/bedrock_agentcore-1.18.1.tar.gz", hash = "sha256:ed4aa8822e39aa5846b9d68d1461afee19f2f795c1f6d71a61bc650ecc00ee31", size = 1030729, upload-time = "2026-07-17T19:55:21.354Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/c7/d80bcb9ba295485f27affe3405a45c71ad4bf82d547715b82ae47206d478/bedrock_agentcore-1.17.0-py3-none-any.whl", hash = "sha256:ef1c3acd3f1bd2bd5a01b0cd70510a4c8ca999abe87f9c43fa52e68484776815", size = 431835, upload-time = "2026-07-02T15:42:25.209Z" },
+    { url = "https://files.pythonhosted.org/packages/45/fe/26cc0a66920035d2740c062bd46df252b15708b7723e13ccae0ab7b334db/bedrock_agentcore-1.18.1-py3-none-any.whl", hash = "sha256:6d8001f09cdfca0a20650ea691426149f521037d8d56917057fc191c00801086", size = 450684, upload-time = "2026-07-17T19:55:19.334Z" },
 ]
 
 [[package]]

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@astrojs/markdown-remark": "7.2.0",
     "@astrojs/mdx": "6.0.3",
     "basic-ftp": "^5.2.2",
+    "brace-expansion": "^5.0.8",
     "defu": "^6.1.6",
     "esbuild": "^0.28.1",
     "fast-xml-parser": "^5.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3676,11 +3676,6 @@ bail@^2.0.0:
   resolved "https://registry.yarnpkg.com/bail/-/bail-2.0.2.tgz#d26f5cd8fe5d6f832a31517b9f7c356040ba6d5d"
   integrity sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==
 
-balanced-match@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
-  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
-
 balanced-match@^4.0.2:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
@@ -3720,25 +3715,10 @@ bowser@^2.11.0:
   resolved "https://registry.yarnpkg.com/bowser/-/bowser-2.14.1.tgz#4ea39bf31e305184522d7ad7bfd91389e4f0cb79"
   integrity sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==
 
-brace-expansion@^1.1.7:
-  version "1.1.16"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
-  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
-  dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
-
-brace-expansion@^2.0.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
-  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
-  dependencies:
-    balanced-match "^1.0.0"
-
-brace-expansion@^5.0.5:
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
-  integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
+brace-expansion@^1.1.7, brace-expansion@^2.0.2, brace-expansion@^5.0.5, brace-expansion@^5.0.8:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
+  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
   dependencies:
     balanced-match "^4.0.2"
 
@@ -3968,11 +3948,6 @@ common-ancestor-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/common-ancestor-path/-/common-ancestor-path-2.0.0.tgz#f1d361aea9236aad5b92a0ff5b9df1422dd360ff"
   integrity sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==
-
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 constructs@^10.6.0:
   version "10.6.0"


### PR DESCRIPTION
## Problem

The `security:deps` job has been **failing on `main` itself** since the 2026-07-06 scheduled run (also 07-13, 07-20), on advisories published against already-resolved dependencies rather than anything a PR changed. Because the gate runs per-PR, it currently fails every open PR as a side effect — e.g. #653, which touches no lockfile or manifest at all.

```
Total 4 packages affected by 4 known vulnerabilities (0 Critical, 4 High, 0 Medium, 0 Low)

| OSV URL                             | CVSS | ECOSYSTEM | PACKAGE           | VERSION | FIXED   |
| https://osv.dev/GHSA-j6g5-3hh3-pgw8 | 8.4  | PyPI      | bedrock-agentcore | 1.17.0  | 1.18.1  |
| https://osv.dev/GHSA-mh99-v99m-4gvg | 7.5  | npm       | brace-expansion   | 1.1.16  | 5.0.8   |
| https://osv.dev/GHSA-mh99-v99m-4gvg | 7.5  | npm       | brace-expansion   | 2.1.2   | 5.0.8   |
| https://osv.dev/GHSA-mh99-v99m-4gvg | 7.5  | npm       | brace-expansion   | 5.0.7   | 5.0.8   |
```

## Fix

**`brace-expansion` (GHSA-mh99-v99m-4gvg, 7.5)** — DoS via unbounded expansion length causing an OOM crash. Three ranges were in the tree (`^1.1.7`, `^2.0.2`, `^5.0.5`, via `minimatch` 3.x / 9.x / 10.x), resolving to 1.1.16 / 2.1.2 / 5.0.7.

The advisory covers **everything `<= 5.0.7`**, so the v1 and v2 lines have no patched release inside their own majors — a plain lockfile re-resolve cannot fix them, which is why this needs a `resolutions` entry rather than the usual re-resolve-only change. `"brace-expansion": "^5.0.8"` collapses all three ranges onto the patched version. The package is transitive-only; nothing declares it directly.

**`bedrock-agentcore` (GHSA-j6g5-3hh3-pgw8, 8.4)** — improper neutralization of argument delimiters in the Python SDK's `install_packages()`. This one is exact-pinned in `agent/pyproject.toml`, so it is a deliberate **1.17.0 → 1.18.1** bump (1.18.1 is both the first patched version and the current latest).

## Verification

- `osv-scanner` across all three lockfiles: **`No issues found`** (was 4 High).
- `mise run build` green — cdk **2526** tests / cli / agent **1298**.
- The bumped SDK's one runtime touchpoint — `BedrockAgentCoreContext.set_workload_access_token`, used by the workload-token bridge in `agent/src/server.py` — was checked to still exist in 1.18.1. Worth calling out because the agent tests mock that import, so the suite passing alone would not have proven it.

Lockfile + pin only; no source changes.

Follows the same shape as #637 and #639.