### PR TITLE
chore(deps): prune inert root resolutions pins (basic-ftp, defu, esbuild, postcss, uuid, vite)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,18 +24,12 @@
   "resolutions": {
     "@astrojs/markdown-remark": "7.2.0",
     "@astrojs/mdx": "6.0.3",
-    "basic-ftp": "^5.2.2",
     "brace-expansion": "^5.0.9",
-    "defu": "^6.1.6",
-    "esbuild": "^0.28.1",
     "fast-uri": "^3.1.5",
     "fast-xml-parser": "^5.7.0",
     "ip-address": "^10.3.1",
     "js-yaml": "^4.2.0",
-    "postcss": "^8.5.18",
     "undici": "^7.29.0",
-    "uuid": "^14.0.0",
-    "vite": "^8.0.13",
     "yaml": "^2.8.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3679,7 +3679,7 @@ baseline-browser-mapping@^2.10.42:
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz#195dcc76baa269a497f0b07decace169fee9ac58"
   integrity sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==
 
-basic-ftp@^5.0.2, basic-ftp@^5.2.2:
+basic-ftp@^5.0.2:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.3.1.tgz#3148ee9af43c0522514a4f973fecb1d3cbb6d71e"
   integrity sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==
@@ -7277,7 +7277,7 @@ postcss-selector-parser@^6.1.1:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-postcss@^8.4.38, postcss@^8.5.16, postcss@^8.5.18:
+postcss@^8.4.38, postcss@^8.5.16:
   version "8.5.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.23.tgz#3493550116f478487298301d2c2e8dc5a56e6594"
   integrity sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==


### PR DESCRIPTION
## What

Prune **6 inert pins** from the root `package.json` `resolutions` block: `basic-ftp`, `defu`, `esbuild`, `postcss`, `uuid`, `vite`.

## Why

A `resolutions` floor only earns its keep if it prevents a CI cycle that would otherwise happen. These 6 don't:

- **They constrain nothing today.** Measured empirically (strip all resolutions → `yarn install` → diff) on #711's branch and re-confirmed here: each resolves to the **identical version** with or without its pin (see table below).
- **The OSV gate already covers the security case.** `//:security:deps` (osv-scanner) is in-path on every lockfile change — PR gate *and* scheduled suite — so a known-vulnerable version can't re-enter unnoticed whether or not a floor exists. And a floor can't help against a *not-yet-disclosed* CVE (you'd have to already know it to set the floor).
- **A couple actively cost cycles.** An `esbuild` / `vite` / `postcss` floor will *block* a legitimate minor upgrade → a failed/blocked-resolution cycle someone has to debug. That's the opposite of cycle prevention.
- **Audit noise.** An inert pin *looks* load-bearing; it took a strip-and-rescan experiment to prove otherwise.

## What is kept (and why)

| Kept pin | Category | Removing it would… |
| --- | --- | --- |
| `brace-expansion`, `js-yaml`, `yaml`, `fast-xml-parser`, `@astrojs/markdown-remark`, `@astrojs/mdx` | **compatibility** (holds *below* natural resolution) | change/break the build (drops to older major or drops the pkg) |
| `fast-uri`, `undici`, `ip-address` | **remediation floor** (demonstrated, just-patched CVE in #711) | remove cheap insurance where in-range re-regression is empirically plausible |

## Verification

| Package | resolved w/ pin | resolved w/o pin |
| --- | --- | --- |
| basic-ftp | 5.3.1 | 5.3.1 |
| defu | 6.1.7 | 6.1.7 |
| esbuild | 0.28.1 | 0.28.1 |
| postcss | 8.5.23 | 8.5.23 |
| uuid | 14.0.1 | 14.0.1 |
| vite | 8.1.3 | 8.1.3 |

- **Zero resolution drift** across all 15 formerly-pinned packages after prune.
- `osv-scanner` across all three lockfiles → **"No issues found"**.
- **3473 cdk tests pass**; TypeScript compiles. (Local `cdk synth` needs live `ec2:DescribeAvailabilityZones` credentials this box lacks — CI runs it.)

## Guardrail

This rests on the OSV gate staying **blocking and in-path**. It regressed once (#699) and has coverage seams (#712). **Do not prune the remaining floors if the gate is ever made non-blocking** — at that point they become the only line of defense.

## Scope

Pure `resolutions` hygiene — subtractive, lockfile-only. Follows #711 (OSV remediation). Sibling to #712 (resolutions/overrides parity); this lands **first** so #712 reasons about the final minimal pin set.

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)
