### PR TITLE
chore(security): guard transitive-dep pin drift across yarn.lock and jira-forge-app lockfile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ Branch names: `(feat|fix|chore|docs)/<issue-number>-short-description` (e.g. `do
 - **Branch without issue number** — Unauthorized work.
 - **`MISE_EXPERIMENTAL=1`** — Required for `mise //cdk:build` and other namespaced tasks ([CONTRIBUTING.md](./CONTRIBUTING.md)).
 - **`prek install` fails** — Another hook manager owns `core.hooksPath`; see [CONTRIBUTING.md](./CONTRIBUTING.md).
+- **Transitive npm pin applied in only one place** — `integrations/jira-forge-app` is a standalone npm project *outside* the yarn workspaces, so a root `package.json` `resolutions` bump does **not** reach it. Mirror the pin into `integrations/jira-forge-app/package.json` `overrides` and re-lock (`npm install --package-lock-only`). `mise run drift-prevention` (`check:transitive-pin-sync`) fails locally if they drift. See [#712](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/issues/712).
 - **Package-specific pitfalls** — API type drift, CDK test bundling, Cedar parity, generated docs: see package `AGENTS.md` files.
 
 ## Tech stack

--- a/mise.toml
+++ b/mise.toml
@@ -106,6 +106,10 @@ run = "yarn knip"
 description = "Dead-code ratchet (#282): fail only if knip's issue count rises above knip-baseline.json. Advisory in CI for now; flips to blocking once the baseline is driven to zero."
 run = "node scripts/check-deadcode-ratchet.mjs"
 
+[tasks."check:transitive-pin-sync"]
+description = "Transitive-pin sync guard (#712): fail if a package pinned in root `resolutions` resolves below that floor in integrations/jira-forge-app's npm lockfile — the standalone project root `resolutions` can't reach."
+run = "node scripts/check-transitive-pin-sync.mjs"
+
 [tasks."drift-prevention"]
 description = "Run checks to prevent drift in contracts between packages and documentation links"
 run = [
@@ -113,6 +117,7 @@ run = [
   { task = "check:constants-sync" },
   { task = "check:types-sync" },
   { task = "check:coverage-thresholds-sync" },
+  { task = "check:transitive-pin-sync" },
   { task = "//docs:link-check" },
 ]
 

--- a/scripts/check-transitive-pin-sync.mjs
+++ b/scripts/check-transitive-pin-sync.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ *  MIT No Attribution
+ *
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy of
+ *  the Software without restriction, including without limitation the rights to
+ *  use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ *  the Software, and to permit persons to whom the Software is furnished to do so.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+/**
+ * Transitive-pin sync guard (issue #712).
+ *
+ * The repo pins transitive npm dependencies in TWO independent places that do
+ * not share state:
+ *   - root `package.json` -> `resolutions`   governs the yarn workspace (yarn.lock)
+ *   - `integrations/jira-forge-app/package.json` -> `overrides`
+ *                                             governs that standalone npm project
+ *                                             (its own package-lock.json)
+ * jira-forge-app is OUTSIDE the yarn `workspaces` array, so a bump applied via
+ * root `resolutions` never reaches it. A maintainer remediating a shared
+ * transitive advisory (e.g. fast-uri, undici) can clear yarn.lock and pass the
+ * LOCAL `security:deps`, while the same advisory silently persists in the
+ * jira-forge-app lockfile until the scheduled/CI scan fails days later.
+ *
+ * This guard fails fast, locally, when the two drift: for every package that is
+ * pinned in root `resolutions` AND also present in the jira-forge-app lockfile,
+ * the version resolved there must meet the root pin's minimum. If it does not,
+ * the fix is to mirror the pin into jira-forge-app `overrides` and re-lock
+ * (`npm install --package-lock-only`).
+ *
+ * It intentionally does NOT require every root pin to appear in jira-forge-app —
+ * only packages actually present in both trees must agree. A pin for a package
+ * jira-forge-app doesn't depend on is a no-op there and is not flagged.
+ *
+ * No third-party deps by design: every other script in scripts/ uses only
+ * `node:` builtins, and scripts/** is knip-ignored, so pulling in `semver`
+ * would be an undeclared/transitive import that could vanish on a re-lock. The
+ * repo's transitive pins are all `^`/`>=`-style minimum FLOORS, so a
+ * "resolved >= floor" numeric compare on the leading `major.minor.patch` is the
+ * exact check we need — no range engine required.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const rootPkgPath = join(repoRoot, 'package.json');
+const forgeLockPath = join(
+  repoRoot,
+  'integrations',
+  'jira-forge-app',
+  'package-lock.json',
+);
+
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (err) {
+    console.error(`check-transitive-pin-sync: cannot read ${path}: ${err.message}`);
+    process.exit(2);
+  }
+}
+
+/** Parse the leading numeric release of a semver into [major, minor, patch]. */
+function releaseTuple(version) {
+  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(version);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+/** Strip a range operator (^, ~, >=, v) to the bare minimum version string. */
+function floorOf(range) {
+  return String(range).trim().replace(/^[\^~]|^>=\s*|^v/i, '');
+}
+
+/** True iff `version` is >= the minimum implied by `range`; null if unparseable. */
+function meetsFloor(version, range) {
+  const v = releaseTuple(version);
+  const f = releaseTuple(floorOf(range));
+  if (!v || !f) return null;
+  for (let i = 0; i < 3; i++) {
+    if (v[i] > f[i]) return true;
+    if (v[i] < f[i]) return false;
+  }
+  return true; // exactly equal
+}
+
+const rootPkg = readJson(rootPkgPath);
+const resolutions = rootPkg.resolutions ?? {};
+if (typeof resolutions !== 'object' || Array.isArray(resolutions)) {
+  console.error(
+    'check-transitive-pin-sync: root package.json `resolutions` is not an object — schema changed.',
+  );
+  process.exit(2);
+}
+
+// Collect every resolved version of every package present in the jira-forge-app
+// lockfile. npm v2/v3 lockfiles key `packages` by install path; the package name
+// is the final segment after the last `node_modules/`. The root entry ("") is
+// skipped.
+const forgeLock = readJson(forgeLockPath);
+if (!forgeLock.packages || typeof forgeLock.packages !== 'object') {
+  console.error(
+    `check-transitive-pin-sync: ${forgeLockPath} has no \`packages\` map — expected an npm v2/v3 lockfile.`,
+  );
+  process.exit(2);
+}
+const forgeVersions = new Map(); // name -> Set<version>
+for (const [installPath, meta] of Object.entries(forgeLock.packages)) {
+  if (installPath === '' || !meta?.version) continue;
+  const name = installPath.split('node_modules/').pop();
+  if (!forgeVersions.has(name)) forgeVersions.set(name, new Set());
+  forgeVersions.get(name).add(meta.version);
+}
+
+const drifts = [];
+const checked = [];
+for (const [name, range] of Object.entries(resolutions)) {
+  const present = forgeVersions.get(name);
+  if (!present) continue; // not a jira-forge-app dependency — pin is a no-op there
+  for (const version of present) {
+    const ok = meetsFloor(version, range);
+    if (ok === null) {
+      console.error(
+        `check-transitive-pin-sync: cannot compare ${name}@${version} against pin "${range}" ` +
+          `(unparseable version or range).`,
+      );
+      process.exit(2);
+    }
+    checked.push(`${name}@${version} (root pin ${range})`);
+    if (!ok) drifts.push({ name, range, version });
+  }
+}
+
+if (drifts.length > 0) {
+  console.error('check-transitive-pin-sync: transitive pins have DRIFTED between');
+  console.error('root `resolutions` and integrations/jira-forge-app `overrides`.\n');
+  for (const { name, range, version } of drifts) {
+    console.error(
+      `  ✖ ${name}: root pins "${range}" but jira-forge-app resolves ${version}`,
+    );
+    console.error(
+      `      fix: add "${name}": "${range}" to integrations/jira-forge-app/package.json "overrides",`,
+    );
+    console.error(
+      `           then \`cd integrations/jira-forge-app && npm install --package-lock-only\`.\n`,
+    );
+  }
+  console.error(
+    `Drifted: ${drifts.length}. This is the failure mode #712 guards against — ` +
+      `a root resolutions bump that never reached the standalone npm project.`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `check-transitive-pin-sync: OK — ${checked.length} shared pin(s) in sync ` +
+    `between root resolutions and jira-forge-app.`,
+);


### PR DESCRIPTION
## Problem

The repo pins transitive npm deps in **two independent places that don't share state**:

| Lockfile | Project | Pin mechanism |
| --- | --- | --- |
| `yarn.lock` | root yarn workspace (`cdk`, `cli`, `docs`) | root `package.json` → `resolutions` |
| `integrations/jira-forge-app/package-lock.json` | standalone npm project (`@abca/jira-forge-app`) | its own `package.json` → `overrides` |

`jira-forge-app` is **outside** the yarn workspaces array, so a root `resolutions` bump never reaches it. A maintainer remediating a shared transitive advisory (e.g. `fast-uri`, `undici`) can clear `yarn.lock` and pass the **local** `security:deps`, while the same advisory silently persists in jira-forge-app until CI fails days later — exactly what happened on #711 ([run 30936422703](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/actions/runs/30936422703)).

## Fix (issue #712, option 1: doc + guard)

- **`scripts/check-transitive-pin-sync.mjs`** — for every package pinned in root `resolutions` that is **also present** in the jira-forge-app lockfile, assert the version resolved there meets the root pin's floor; fail with an actionable fix message otherwise. Intentionally does *not* require every root pin to appear in jira-forge-app — only packages in **both** trees must agree.
- **`mise.toml`** — `check:transitive-pin-sync` task, wired into `drift-prevention` next to the existing constants/types/coverage sync checks.
- **`AGENTS.md`** — Common-mistakes note documenting the two-place pinning rule.

### Design note
No third-party deps: uses only `node:` builtins, matching every other `scripts/*.mjs` (and `scripts/**` is knip-ignored, so a `semver` import would be undeclared and could vanish on a re-lock). The repo's transitive pins are all `^`/`>=` **floors**, so a numeric `major.minor.patch >=` compare is exactly the needed check — no range engine required.

## Verification

- ✅ Passes on current `main` state: `OK — 4 shared pin(s) in sync`.
- ✅ **Fails on a simulated `undici` downgrade** in the forge lockfile, printing the exact `overrides` fix — then passes again after restore.
- ✅ Runs green via `mise run check:transitive-pin-sync`.
- ✅ `mise //docs:sync` produces no mirror drift (AGENTS.md is not a mirrored source).

## Scope / sequencing

Branched off `main` (independent of #717/#714). Guards the `security:deps` surface; does **not** change any pinned version. Sibling to #714 (prune inert pins) — recommend landing **#714 first** so this guard reasons about the final minimal pin set, though the two don't conflict (disjoint files).

Closes #712

🤖 Generated with [Claude Code](https://claude.com/claude-code)
