### PR TITLE
fix(security): registry frontmatter parse failure erases publisher attribution — surface as typed rejection (#756 Cat 1)

### DIFF
--- a/agent/src/registry/agent_registry_client.py
+++ b/agent/src/registry/agent_registry_client.py
@@ -34,12 +34,25 @@ _RUNTIME_META_KEY = "dev.abca.runtime"
 # Frontmatter key carrying the runtime payload (JSON) in a native SKILL record's
 # SKILL.md — mirrors SKILL_RUNTIME_FM_KEY in registry/agent-registry-client.ts.
 _SKILL_RUNTIME_FM_KEY = "x-abca-runtime"
-# Match the whole frontmatter block between the first ---/--- pair. We parse that
-# block as one YAML document (not a per-line regex) so a caller-controlled
-# `description` containing a newline cannot inject a shadowing runtime key
-# (#246 review B1/B2) — mirrors parseSkillFrontmatter in agent-registry-client.ts.
+# Match the whole frontmatter block between the first ---/--- pair. Parsing it as
+# one YAML document (not a per-line regex) keeps a newline-bearing value inside its
+# value instead of being read as a second key — but the injection defense proper is
+# write-side (buildSkillMd quotes/escapes every value through a YAML dumper); this
+# read only avoids masking corruption (#791). Mirrors parseSkillFrontmatter in
+# agent-registry-client.ts.
 _SKILL_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
 _RESOLVABLE_STATUSES = ("APPROVED", "DEPRECATED")
+
+
+def _decode_descriptor_json(data: str, what: str) -> Any:
+    """json.loads a descriptor body, boxing a parse failure as a malformed marker
+    (not a raw ValueError) so a corrupt CUSTOM/MCP/runtime body classifies as
+    MALFORMED rather than REMOVED — mirrors parseDescriptorJson in
+    agent-registry-client.ts."""
+    try:
+        return json.loads(data)
+    except (ValueError, TypeError) as exc:
+        raise RegistryRecordMalformedError(f"{what} is not valid JSON: {exc}") from exc
 
 
 class AgentRegistryClient:
@@ -71,7 +84,9 @@ class AgentRegistryClient:
         descriptors = raw.get("descriptors", {}) or {}
         record_type = raw.get("recordType")
         if record_type == "CUSTOM":
-            body = json.loads(descriptors.get("custom", {}).get("data", "{}"))
+            body = _decode_descriptor_json(
+                descriptors.get("custom", {}).get("data", "{}"), "CUSTOM record body"
+            )
             return body.get("runtime", {})
         if record_type == "SKILL":
             # SKILL.md is Markdown frontmatter, not JSON — recover the runtime
@@ -103,13 +118,20 @@ class AgentRegistryClient:
             if not isinstance(raw_value, str):
                 return {}
             # Legacy form: raw JSON (YAML already unwrapped its single-quoting, so
-            # the value starts with `{`). New form: base64-encoded JSON.
-            if raw_value.lstrip().startswith("{"):
-                return json.loads(raw_value)
-            return json.loads(base64.b64decode(raw_value).decode("utf-8"))
+            # the value starts with `{`). New form: base64-encoded JSON. A present
+            # but undecodable value is boxed as MALFORMED (not left to raise a bare
+            # ValueError) so resolve() rejects it the same way it does bad YAML.
+            try:
+                if raw_value.lstrip().startswith("{"):
+                    return json.loads(raw_value)
+                return json.loads(base64.b64decode(raw_value).decode("utf-8"))
+            except (ValueError, TypeError) as exc:
+                raise RegistryRecordMalformedError(
+                    f"SKILL.md {_SKILL_RUNTIME_FM_KEY} is not decodable base64/JSON: {exc}"
+                ) from exc
         # MCP: JSON server.json with the runtime in a `_meta` block.
         inline = descriptors.get("mcpServer", {}).get("data") or "{}"
-        body = json.loads(inline)
+        body = _decode_descriptor_json(inline, "MCP server.json body")
         return body.get("_meta", {}).get(_RUNTIME_META_KEY, {})
 
     def _list_records(self, kind: str, namespace: str) -> list[dict[str, Any]]:
@@ -148,6 +170,12 @@ class AgentRegistryClient:
         for raw in self._list_records(kind, namespace):
             _, _, dname = self._decode_name(raw.get("name", ""))
             if dname == name and raw.get("recordVersion") == version:
+                # Fail closed on the targeted record: a malformed descriptor erased
+                # its publisher/runtime, so surface the parse failure (via
+                # _extract_runtime) rather than hand back a record whose attribution
+                # is silently gone. Mirrors getRecord in agent-registry-client.ts,
+                # which throws RegistryRecordMalformedError for the same case (#791).
+                self._extract_runtime(raw)
                 return raw
         return None
 
@@ -170,27 +198,23 @@ class AgentRegistryClient:
                 f"satisfies {ref.constraint.raw}",
             )
         winner = by_version[winning]
-        # Fail closed: a resolvable record whose runtime payload is empty or
-        # unreadable must NOT resolve to {} — that would let a task load nothing
-        # while the audit claims the pin was honored (REGISTRY.md §8). A corrupt
-        # _meta/CUSTOM body or an out-of-band write can produce this.
+        # Fail closed: a resolvable record whose runtime payload is empty must NOT
+        # resolve to {} — that would let a task load nothing while the audit claims
+        # the pin was honored (REGISTRY.md §8). An out-of-band write can produce an
+        # empty runtime; a corrupt descriptor is caught below as MALFORMED.
         try:
             runtime = self._extract_runtime(winner)
         except RegistryRecordMalformedError as exc:
-            # Distinct from REMOVED: the payload is present but unparseable, so its
+            # Distinct from REMOVED: the descriptor (frontmatter, x-abca-runtime
+            # value, or CUSTOM/MCP body) is present but unparseable, so its
             # attribution/runtime were erased — reject rather than trust `{}` (#791).
+            # _extract_runtime boxes every parse/decode failure as this error, so
+            # both languages classify a corrupt descriptor as MALFORMED (not REMOVED).
             raise RegistryResolutionError(
                 "MALFORMED",
                 ref_str,
                 f"resolved {ref.kind}/{ref.namespace}/{ref.name}@{winning} "
-                f"has malformed frontmatter: {exc}",
-            ) from exc
-        except (ValueError, json.JSONDecodeError) as exc:
-            raise RegistryResolutionError(
-                "REMOVED",
-                ref_str,
-                f"resolved {ref.kind}/{ref.namespace}/{ref.name}@{winning} "
-                f"has an unreadable runtime payload: {exc}",
+                f"has a malformed descriptor: {exc}",
             ) from exc
         if not isinstance(runtime, dict) or not runtime:
             raise RegistryResolutionError(

--- a/agent/src/registry/agent_registry_client.py
+++ b/agent/src/registry/agent_registry_client.py
@@ -44,15 +44,22 @@ _SKILL_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
 _RESOLVABLE_STATUSES = ("APPROVED", "DEPRECATED")
 
 
-def _decode_descriptor_json(data: str, what: str) -> Any:
-    """json.loads a descriptor body, boxing a parse failure as a malformed marker
-    (not a raw ValueError) so a corrupt CUSTOM/MCP/runtime body classifies as
-    MALFORMED rather than REMOVED — mirrors parseDescriptorJson in
-    agent-registry-client.ts."""
+def _decode_descriptor_json(data: str, what: str) -> dict[str, Any]:
+    """json.loads a CUSTOM/MCP descriptor body into a dict, boxing any failure as a
+    malformed marker (not a raw ValueError/AttributeError) so a corrupt body
+    classifies as MALFORMED rather than REMOVED — mirrors parseDescriptorJson in
+    agent-registry-client.ts. ``json.loads`` also succeeds on non-objects
+    (``null``, ``[1,2]``, ``123``, ``"s"``), and the caller immediately calls
+    ``.get`` on the result — so a successful parse that is not a dict is rejected
+    here rather than raising an unboxed AttributeError that would escape resolve()
+    as an opaque error (#837 review)."""
     try:
-        return json.loads(data)
+        parsed = json.loads(data)
     except (ValueError, TypeError) as exc:
         raise RegistryRecordMalformedError(f"{what} is not valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise RegistryRecordMalformedError(f"{what} is not a JSON object")
+    return parsed
 
 
 class AgentRegistryClient:
@@ -112,8 +119,15 @@ class AgentRegistryClient:
                 raise RegistryRecordMalformedError(
                     f"SKILL.md frontmatter is not valid YAML: {exc}"
                 ) from exc
-            if not isinstance(fm, dict):
+            # An empty block (`---\n\n---`) parses to None — a record legitimately
+            # without frontmatter. A block that parses to a non-mapping (a sequence
+            # or a bare scalar) is corrupt: reject it as MALFORMED rather than
+            # collapse to `{}`, which would hide the corruption the way an
+            # unparseable block would (#791 / #837 review).
+            if fm is None:
                 return {}
+            if not isinstance(fm, dict):
+                raise RegistryRecordMalformedError("SKILL.md frontmatter is not a mapping")
             raw_value = fm.get(_SKILL_RUNTIME_FM_KEY)
             if not isinstance(raw_value, str):
                 return {}
@@ -129,10 +143,16 @@ class AgentRegistryClient:
                 raise RegistryRecordMalformedError(
                     f"SKILL.md {_SKILL_RUNTIME_FM_KEY} is not decodable base64/JSON: {exc}"
                 ) from exc
-        # MCP: JSON server.json with the runtime in a `_meta` block.
+        # MCP: JSON server.json with the runtime in a `_meta` block. A valid
+        # server.json may carry a non-object `_meta` (or none); guard the shape so
+        # `{"_meta": "x"}` does not raise an unboxed AttributeError — mirrors the
+        # dict guard in extractPayload in agent-registry-client.ts (#837 review).
         inline = descriptors.get("mcpServer", {}).get("data") or "{}"
         body = _decode_descriptor_json(inline, "MCP server.json body")
-        return body.get("_meta", {}).get(_RUNTIME_META_KEY, {})
+        meta = body.get("_meta")
+        if not isinstance(meta, dict):
+            return {}
+        return meta.get(_RUNTIME_META_KEY, {})
 
     def _list_records(self, kind: str, namespace: str) -> list[dict[str, Any]]:
         out: list[dict[str, Any]] = []
@@ -175,7 +195,9 @@ class AgentRegistryClient:
                 # _extract_runtime) rather than hand back a record whose attribution
                 # is silently gone. Mirrors getRecord in agent-registry-client.ts,
                 # which throws RegistryRecordMalformedError for the same case (#791).
-                self._extract_runtime(raw)
+                # Called for its side effect: it raises if the descriptor is
+                # malformed; the parsed value is discarded (get_record returns raw).
+                _ = self._extract_runtime(raw)
                 return raw
         return None
 
@@ -210,11 +232,15 @@ class AgentRegistryClient:
             # attribution/runtime were erased — reject rather than trust `{}` (#791).
             # _extract_runtime boxes every parse/decode failure as this error, so
             # both languages classify a corrupt descriptor as MALFORMED (not REMOVED).
+            # Keep the parser text (which can echo raw descriptor bytes) off the
+            # message and on the exception chain (`from exc`) only — the TS twin
+            # returns this reason on an open 422, so neither side leaks the payload
+            # (#837 review).
             raise RegistryResolutionError(
                 "MALFORMED",
                 ref_str,
                 f"resolved {ref.kind}/{ref.namespace}/{ref.name}@{winning} "
-                f"has a malformed descriptor: {exc}",
+                f"has a malformed descriptor",
             ) from exc
         if not isinstance(runtime, dict) or not runtime:
             raise RegistryResolutionError(

--- a/agent/src/registry/agent_registry_client.py
+++ b/agent/src/registry/agent_registry_client.py
@@ -15,7 +15,11 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 
-from registry.client import RegistryResolutionError, ResolvedAsset
+from registry.client import (
+    RegistryRecordMalformedError,
+    RegistryResolutionError,
+    ResolvedAsset,
+)
 from registry.resolver import select_highest
 
 if TYPE_CHECKING:
@@ -83,9 +87,16 @@ class AgentRegistryClient:
                 return {}
             try:
                 fm = yaml.safe_load(m.group(1))
-            except yaml.YAMLError:
-                # nosemgrep: py-silent-success-masking -- invalid YAML is unreadable payload
-                return {}
+            except yaml.YAMLError as exc:
+                # A YAML parse failure must NOT collapse to `{}`: that erases the
+                # publisher (attribution) and runtime, making a malformed record
+                # indistinguishable from an empty one and letting attacker-influenced
+                # input drop an audit-critical trust field (#791). Surface it so
+                # resolve() rejects the record. Mirrors parseSkillFrontmatter in
+                # agent-registry-client.ts.
+                raise RegistryRecordMalformedError(
+                    f"SKILL.md frontmatter is not valid YAML: {exc}"
+                ) from exc
             if not isinstance(fm, dict):
                 return {}
             raw_value = fm.get(_SKILL_RUNTIME_FM_KEY)
@@ -165,6 +176,15 @@ class AgentRegistryClient:
         # _meta/CUSTOM body or an out-of-band write can produce this.
         try:
             runtime = self._extract_runtime(winner)
+        except RegistryRecordMalformedError as exc:
+            # Distinct from REMOVED: the payload is present but unparseable, so its
+            # attribution/runtime were erased — reject rather than trust `{}` (#791).
+            raise RegistryResolutionError(
+                "MALFORMED",
+                ref_str,
+                f"resolved {ref.kind}/{ref.namespace}/{ref.name}@{winning} "
+                f"has malformed frontmatter: {exc}",
+            ) from exc
         except (ValueError, json.JSONDecodeError) as exc:
             raise RegistryResolutionError(
                 "REMOVED",

--- a/agent/src/registry/client.py
+++ b/agent/src/registry/client.py
@@ -33,13 +33,25 @@ class ResolvedAsset:
 
 class RegistryResolutionError(Exception):
     """Raised when a ref cannot be resolved. ``reason`` matches the TS token set
-    (``NO_MATCHING_VERSION`` / ``REMOVED`` / ``INVALID_CONSTRAINT`` /
-    ``INVALID_REGISTRY_REF``) so both languages agree on *why*."""
+    (``NO_MATCHING_VERSION`` / ``REMOVED`` / ``MALFORMED`` /
+    ``INVALID_CONSTRAINT`` / ``INVALID_REGISTRY_REF``) so both languages agree on
+    *why*."""
 
     def __init__(self, reason: str, ref: str, message: str) -> None:
         super().__init__(message)
         self.reason = reason
         self.ref = ref
+
+
+class RegistryRecordMalformedError(Exception):
+    """Raised when a record's descriptor payload is present but unparseable — e.g.
+    a SKILL.md frontmatter block that fails to YAML-parse. Distinct from an
+    *absent* record and from an *empty* runtime: a malformed payload must be
+    rejected, not silently collapsed to ``{}``. Collapsing erases the publisher
+    (attribution) and runtime, making a malformed record indistinguishable from a
+    legitimately empty one and letting attacker-influenced input drop an
+    audit-critical trust field (#791). Mirrors ``RegistryRecordMalformedError`` in
+    ``cdk/src/handlers/shared/registry/types.ts``."""
 
 
 class RegistryClient(Protocol):

--- a/agent/src/registry/client.py
+++ b/agent/src/registry/client.py
@@ -49,13 +49,13 @@ class RegistryRecordMalformedError(Exception):
     value that is not decodable base64/JSON, or a CUSTOM/MCP body that is not valid
     JSON. Distinct from an *absent* record and from an *empty* runtime: a malformed
     payload must be rejected, not silently collapsed to ``{}``. Collapsing erases
-    the publisher (attribution) and runtime, making a malformed record
-    indistinguishable from a legitimately empty one and letting attacker-influenced
-    input drop an audit-critical trust field (#791). Mirrors
-    ``RegistryRecordMalformedError`` in
-    ``cdk/src/handlers/shared/registry/types.ts`` (the TS twin additionally carries
-    a ``reason`` discriminator and ``cause``; the agent only needs the fail-closed
-    signal, so those are intentionally omitted here)."""
+    the runtime the agent is here to load (and, on the TS write/read side, the
+    publisher attribution), making a malformed record indistinguishable from a
+    legitimately empty one (#791). Mirrors ``RegistryRecordMalformedError`` in
+    ``cdk/src/handlers/shared/registry/types.ts`` — the TS twin additionally
+    carries an explicit ``reason`` discriminator field the agent has no consumer
+    for, so that field is omitted here; the underlying cause still travels on
+    ``__cause__`` via ``raise ... from exc`` at every raise site."""
 
 
 class RegistryClient(Protocol):

--- a/agent/src/registry/client.py
+++ b/agent/src/registry/client.py
@@ -44,14 +44,18 @@ class RegistryResolutionError(Exception):
 
 
 class RegistryRecordMalformedError(Exception):
-    """Raised when a record's descriptor payload is present but unparseable — e.g.
-    a SKILL.md frontmatter block that fails to YAML-parse. Distinct from an
-    *absent* record and from an *empty* runtime: a malformed payload must be
-    rejected, not silently collapsed to ``{}``. Collapsing erases the publisher
-    (attribution) and runtime, making a malformed record indistinguishable from a
-    legitimately empty one and letting attacker-influenced input drop an
-    audit-critical trust field (#791). Mirrors ``RegistryRecordMalformedError`` in
-    ``cdk/src/handlers/shared/registry/types.ts``."""
+    """Raised when a record's descriptor payload is present but unparseable — a
+    SKILL.md frontmatter block that fails to YAML-parse, an ``x-abca-runtime``
+    value that is not decodable base64/JSON, or a CUSTOM/MCP body that is not valid
+    JSON. Distinct from an *absent* record and from an *empty* runtime: a malformed
+    payload must be rejected, not silently collapsed to ``{}``. Collapsing erases
+    the publisher (attribution) and runtime, making a malformed record
+    indistinguishable from a legitimately empty one and letting attacker-influenced
+    input drop an audit-critical trust field (#791). Mirrors
+    ``RegistryRecordMalformedError`` in
+    ``cdk/src/handlers/shared/registry/types.ts`` (the TS twin additionally carries
+    a ``reason`` discriminator and ``cause``; the agent only needs the fail-closed
+    signal, so those are intentionally omitted here)."""
 
 
 class RegistryClient(Protocol):

--- a/agent/tests/test_registry_agent_registry_client.py
+++ b/agent/tests/test_registry_agent_registry_client.py
@@ -14,7 +14,7 @@ import json
 import pytest
 
 from registry.agent_registry_client import AgentRegistryClient
-from registry.client import RegistryResolutionError
+from registry.client import RegistryRecordMalformedError, RegistryResolutionError
 from registry.ref import parse_ref
 
 _RUNTIME_META_KEY = "dev.abca.runtime"
@@ -106,6 +106,20 @@ class TestExtractRuntime:
         }
         assert _client()._extract_runtime(raw) == {}
 
+    def test_agent_skills_malformed_frontmatter_raises_not_empty(self):
+        # A frontmatter block that is present but not valid YAML (unterminated flow
+        # sequence) must be rejected, not collapsed to `{}` — collapsing erases the
+        # publisher/runtime and hides the corruption (#791).
+        skill_md = "---\nname: x\nx-abca-runtime: [1, 2\n---\nbody"
+        raw = {
+            "recordType": "SKILL",
+            "descriptors": {
+                "agentSkillsDefinition": {"additionalData": {"skillMd": {"data": skill_md}}}
+            },
+        }
+        with pytest.raises(RegistryRecordMalformedError):
+            _client()._extract_runtime(raw)
+
     def test_agent_skills_newline_description_cannot_inject_runtime_key(self):
         # B1 (#246): a description carrying a newline + a second x-abca-runtime
         # line must not shadow the validated runtime. Frontmatter emitted by the
@@ -171,3 +185,24 @@ class TestResolveFailClosed:
                 "registry://mcp_server/acme/pdf-tools@1.4.1",
             )
         assert exc.value.reason == "REMOVED"
+
+    def test_fails_malformed_when_winner_frontmatter_is_unparseable(self):
+        # A malformed frontmatter block must reject the ref as MALFORMED — distinct
+        # from REMOVED (empty) — rather than resolving with erased attribution (#791).
+        skill_md = "---\nname: acme-readme-helper\nx-abca-runtime: [1, 2\n---\nbody"
+        record = {
+            "recordId": "rec-1.0.0",
+            "recordArn": (
+                "arn:aws:agent-registry:us-east-1:123456789012:registry/r/record/rec-1.0.0"
+            ),
+            "name": "skill/acme/readme-helper",
+            "recordType": "SKILL",
+            "descriptors": {
+                "agentSkillsDefinition": {"additionalData": {"skillMd": {"data": skill_md}}}
+            },
+            "recordVersion": "1.0.0",
+            "status": "APPROVED",
+        }
+        with pytest.raises(RegistryResolutionError) as exc:
+            self._resolve([record], "registry://skill/acme/readme-helper@1.0.0")
+        assert exc.value.reason == "MALFORMED"

--- a/agent/tests/test_registry_agent_registry_client.py
+++ b/agent/tests/test_registry_agent_registry_client.py
@@ -138,6 +138,42 @@ class TestExtractRuntime:
         with pytest.raises(RegistryRecordMalformedError):
             _client()._extract_runtime(raw)
 
+    @pytest.mark.parametrize("data", ["null", "123", "[1, 2]", '"just a string"'])
+    def test_custom_non_object_body_raises_malformed(self, data):
+        # json.loads succeeds on these, then body.get would raise a bare
+        # AttributeError — box it as MALFORMED, mirroring parseDescriptorJson's
+        # object check in the TS adapter (#837 review).
+        raw = {"recordType": "CUSTOM", "descriptors": {"custom": {"data": data}}}
+        with pytest.raises(RegistryRecordMalformedError):
+            _client()._extract_runtime(raw)
+
+    @pytest.mark.parametrize("data", ["null", "[1, 2]", '"s"'])
+    def test_mcp_non_object_body_raises_malformed(self, data):
+        raw = {"recordType": "MCP", "descriptors": {"mcpServer": {"data": data}}}
+        with pytest.raises(RegistryRecordMalformedError):
+            _client()._extract_runtime(raw)
+
+    def test_mcp_non_dict_meta_returns_empty_not_crash(self):
+        # `{"_meta": "x"}`: `.get` on a str would raise AttributeError before the
+        # #837 guard. Now it yields an empty runtime (resolve then fails REMOVED).
+        server = {"name": "acme/x", "version": "1.0.0", "_meta": "not-a-dict"}
+        raw = {"recordType": "MCP", "descriptors": {"mcpServer": {"data": json.dumps(server)}}}
+        assert _client()._extract_runtime(raw) == {}
+
+    def test_agent_skills_non_mapping_frontmatter_raises_malformed(self):
+        # Frontmatter that is valid YAML but a sequence/scalar (not a mapping) must
+        # reject as MALFORMED rather than collapse to `{}`, which would hide the
+        # corruption the way an unparseable block would (#791 / #837 review).
+        skill_md = "---\n- a\n- b\n---\nbody"
+        raw = {
+            "recordType": "SKILL",
+            "descriptors": {
+                "agentSkillsDefinition": {"additionalData": {"skillMd": {"data": skill_md}}}
+            },
+        }
+        with pytest.raises(RegistryRecordMalformedError):
+            _client()._extract_runtime(raw)
+
     def test_agent_skills_newline_description_cannot_inject_runtime_key(self):
         # B1 (#246): a description carrying a newline + a second x-abca-runtime
         # line must not shadow the validated runtime. Frontmatter emitted by the
@@ -287,3 +323,46 @@ class TestResolveFailClosed:
         client = AgentRegistryClient("r", _FakeBoto([record]))
         with pytest.raises(RegistryRecordMalformedError):
             client.get_record("skill", "acme", "readme-helper", "1.0.0")
+
+    def test_rejects_malformed_winner_rather_than_downgrading(self):
+        # The TS adapter's highest-value test, mirrored: a valid lower version
+        # exists but the highest matching version is malformed. Silently resolving
+        # the lower one would mask that the pinned (winning) version is corrupt —
+        # reject as MALFORMED instead (#791 / #837 review).
+        def _skill(version: str, runtime_line: str) -> dict:
+            skill_md = f"---\nname: acme-readme-helper\n{runtime_line}\n---\nbody"
+            return {
+                "recordId": f"rec-{version}",
+                "name": "skill/acme/readme-helper",
+                "recordType": "SKILL",
+                "descriptors": {
+                    "agentSkillsDefinition": {"additionalData": {"skillMd": {"data": skill_md}}}
+                },
+                "recordVersion": version,
+                "status": "APPROVED",
+            }
+
+        good = base64.b64encode(json.dumps({"prompt_fragment": "ok"}).encode()).decode()
+        records = [
+            _skill("1.0.0", f"x-abca-runtime: {good}"),
+            _skill("1.1.0", "x-abca-runtime: [1, 2"),  # highest, but unparseable
+        ]
+        with pytest.raises(RegistryResolutionError) as exc:
+            self._resolve(records, "registry://skill/acme/readme-helper@^1.0.0")
+        assert exc.value.reason == "MALFORMED"
+
+    def test_malformed_message_does_not_leak_descriptor_bytes(self):
+        # resolve() returns this reason on an open 422 (via the TS twin); the raw
+        # parser text — which can echo descriptor bytes — must stay off the message
+        # and only on __cause__ (#837 review).
+        record = {
+            "recordId": "rec-1.0.0",
+            "name": "mcp_server/acme/pdf-tools",
+            "recordType": "MCP",
+            "descriptors": {"mcpServer": {"data": '{"_meta": SUPERSECRETTOKEN'}},
+            "recordVersion": "1.0.0",
+            "status": "APPROVED",
+        }
+        with pytest.raises(RegistryResolutionError) as exc:
+            self._resolve([record], "registry://mcp_server/acme/pdf-tools@1.0.0")
+        assert "SUPERSECRETTOKEN" not in str(exc.value)

--- a/agent/tests/test_registry_agent_registry_client.py
+++ b/agent/tests/test_registry_agent_registry_client.py
@@ -120,6 +120,24 @@ class TestExtractRuntime:
         with pytest.raises(RegistryRecordMalformedError):
             _client()._extract_runtime(raw)
 
+    def test_agent_skills_undecodable_runtime_raises_malformed(self):
+        # Frontmatter parses as valid YAML, but x-abca-runtime base64-decodes to a
+        # non-JSON string — must classify as MALFORMED (mirrors the TS adapter),
+        # not collapse to {} or leak a bare ValueError (PR #837 review).
+        bad = base64.b64encode(b"not json").decode()
+        with pytest.raises(RegistryRecordMalformedError):
+            _client()._extract_runtime(self._skill_md(f"x-abca-runtime: {bad}"))
+
+    def test_custom_invalid_json_raises_malformed(self):
+        raw = {"recordType": "CUSTOM", "descriptors": {"custom": {"data": "not json{"}}}
+        with pytest.raises(RegistryRecordMalformedError):
+            _client()._extract_runtime(raw)
+
+    def test_mcp_invalid_json_raises_malformed(self):
+        raw = {"recordType": "MCP", "descriptors": {"mcpServer": {"data": "{bad json"}}}
+        with pytest.raises(RegistryRecordMalformedError):
+            _client()._extract_runtime(raw)
+
     def test_agent_skills_newline_description_cannot_inject_runtime_key(self):
         # B1 (#246): a description carrying a newline + a second x-abca-runtime
         # line must not shadow the validated runtime. Frontmatter emitted by the
@@ -206,3 +224,66 @@ class TestResolveFailClosed:
         with pytest.raises(RegistryResolutionError) as exc:
             self._resolve([record], "registry://skill/acme/readme-helper@1.0.0")
         assert exc.value.reason == "MALFORMED"
+
+    def test_fails_malformed_when_runtime_value_undecodable(self):
+        # Valid YAML frontmatter but an undecodable x-abca-runtime value must be
+        # MALFORMED, not REMOVED — matching the TS adapter (PR #837 review).
+        bad = base64.b64encode(b"not json").decode()
+        skill_md = f"---\nname: acme-readme-helper\nx-abca-runtime: {bad}\n---\nbody"
+        record = {
+            "recordId": "rec-1.0.0",
+            "name": "skill/acme/readme-helper",
+            "recordType": "SKILL",
+            "descriptors": {
+                "agentSkillsDefinition": {"additionalData": {"skillMd": {"data": skill_md}}}
+            },
+            "recordVersion": "1.0.0",
+            "status": "APPROVED",
+        }
+        with pytest.raises(RegistryResolutionError) as exc:
+            self._resolve([record], "registry://skill/acme/readme-helper@1.0.0")
+        assert exc.value.reason == "MALFORMED"
+
+    def test_fails_malformed_when_custom_body_invalid(self):
+        record = {
+            "recordId": "rec-1.0.0",
+            "name": "cedar_policy_module/acme/permit",
+            "recordType": "CUSTOM",
+            "descriptors": {"custom": {"data": "not json{"}},
+            "recordVersion": "1.0.0",
+            "status": "APPROVED",
+        }
+        with pytest.raises(RegistryResolutionError) as exc:
+            self._resolve([record], "registry://cedar_policy_module/acme/permit@1.0.0")
+        assert exc.value.reason == "MALFORMED"
+
+    def test_fails_malformed_when_mcp_body_invalid(self):
+        record = {
+            "recordId": "rec-1.0.0",
+            "name": "mcp_server/acme/pdf-tools",
+            "recordType": "MCP",
+            "descriptors": {"mcpServer": {"data": "{bad json"}},
+            "recordVersion": "1.0.0",
+            "status": "APPROVED",
+        }
+        with pytest.raises(RegistryResolutionError) as exc:
+            self._resolve([record], "registry://mcp_server/acme/pdf-tools@1.0.0")
+        assert exc.value.reason == "MALFORMED"
+
+    def test_get_record_fails_closed_on_malformed_target(self):
+        # Parity with TS getRecord, which throws for a malformed target rather than
+        # handing back a record whose attribution was silently erased (#791).
+        skill_md = "---\nname: acme-readme-helper\nx-abca-runtime: [1, 2\n---\nbody"
+        record = {
+            "recordId": "rec-1.0.0",
+            "name": "skill/acme/readme-helper",
+            "recordType": "SKILL",
+            "descriptors": {
+                "agentSkillsDefinition": {"additionalData": {"skillMd": {"data": skill_md}}}
+            },
+            "recordVersion": "1.0.0",
+            "status": "DRAFT",
+        }
+        client = AgentRegistryClient("r", _FakeBoto([record]))
+        with pytest.raises(RegistryRecordMalformedError):
+            client.get_record("skill", "acme", "readme-helper", "1.0.0")

--- a/cdk/src/handlers/registry-show.ts
+++ b/cdk/src/handlers/registry-show.ts
@@ -48,8 +48,10 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     const client = makeRegistryClient();
     // Browse over entries (not listRecords) so a malformed record still counts:
     // otherwise an asset whose only versions are corrupt would 404 as if absent,
-    // hiding the corruption (#791). Malformed versions surface flagged, with
-    // publisher/created_at null since those live in the erased payload.
+    // hiding the corruption (#791). Malformed versions surface flagged; publisher
+    // is nulled because it lives in the erased payload, and created_at is nulled
+    // by convention (the marker carries only the envelope's name/version/status,
+    // not the envelope timestamp) so a flagged row reads uniformly.
     const entries = (await client.listBrowseEntries({ kind, namespace })).filter(
       (e) => (e.malformed ? e.name : e.record.name) === name,
     );

--- a/cdk/src/handlers/registry-show.ts
+++ b/cdk/src/handlers/registry-show.ts
@@ -46,18 +46,26 @@ export async function handler(event: APIGatewayProxyEvent): Promise<APIGatewayPr
     }
 
     const client = makeRegistryClient();
-    const records = (await client.listRecords({ kind, namespace })).filter((r) => r.name === name);
-    if (records.length === 0) {
+    // Browse over entries (not listRecords) so a malformed record still counts:
+    // otherwise an asset whose only versions are corrupt would 404 as if absent,
+    // hiding the corruption (#791). Malformed versions surface flagged, with
+    // publisher/created_at null since those live in the erased payload.
+    const entries = (await client.listBrowseEntries({ kind, namespace })).filter(
+      (e) => (e.malformed ? e.name : e.record.name) === name,
+    );
+    if (entries.length === 0) {
       return errorResponse(404, ErrorCode.REGISTRY_RECORD_NOT_FOUND, `No asset ${kind}/${namespace}/${name}.`, requestId);
     }
 
-    const versions: RegistryVersionSummary[] = records
-      .map((r) => ({
-        version: r.version,
-        status: r.status,
-        created_at: r.createdAt ?? null,
-        publisher: r.publisher ?? null,
-      }))
+    const versions: RegistryVersionSummary[] = entries
+      .map((e) => (e.malformed
+        ? { version: e.version, status: e.status, created_at: null, publisher: null, malformed: true }
+        : {
+          version: e.record.version,
+          status: e.record.status,
+          created_at: e.record.createdAt ?? null,
+          publisher: e.record.publisher ?? null,
+        }))
       .sort((a, b) => {
         const av = parseVersion(a.version);
         const bv = parseVersion(b.version);

--- a/cdk/src/handlers/shared/registry/agent-registry-client.ts
+++ b/cdk/src/handlers/shared/registry/agent-registry-client.ts
@@ -57,6 +57,7 @@ import {
   RegistryResolutionError,
   type ListFilter,
   type PublishInput,
+  type RegistryBrowseEntry,
   type RegistryRecord,
   type RegistryStatus,
   type ResolvedAsset,
@@ -188,11 +189,12 @@ function buildSkillMd(input: {
  *  legitimately without frontmatter). A block that is present but fails to parse
  *  throws {@link RegistryRecordMalformedError} — it must NOT collapse to `{}`,
  *  which would erase the publisher/runtime and make a malformed record look
- *  empty (#791). Parsing the whole block as one document (rather than a per-line
- *  regex) is what makes key injection via a newline-bearing value impossible — a
- *  duplicate key is a YAML error, and a value's newline stays inside that value;
- *  surfacing that error (rather than swallowing it) is what keeps the injection
- *  defense live. */
+ *  empty (#791). Parsing the whole block as one YAML document (rather than a
+ *  per-line regex) means a newline-bearing value stays inside its value instead
+ *  of being read as a second key — but the injection defense proper is on the
+ *  write side (`buildSkillMd` quotes/escapes via the YAML dumper). Note a
+ *  *duplicate* key does not raise under `json: true` (last value wins), so this
+ *  parse does not itself reject duplicate-key documents. */
 function parseSkillFrontmatter(skillMd: string): Record<string, unknown> {
   const m = skillMd.match(/^---\n([\s\S]*?)\n---/);
   if (!m) return {};
@@ -387,6 +389,20 @@ export class AgentRegistryClient implements RegistryClient {
       out.push(entry);
     }
     return out;
+  }
+
+  async listBrowseEntries(filter?: ListFilter): Promise<readonly RegistryBrowseEntry[]> {
+    // Unlike listRecords, keep malformed records as envelope-only markers so
+    // `show` can surface a corrupt version (flagged) instead of dropping it and
+    // making an all-malformed asset look absent (#791).
+    const entries = await this.loadEntries(filter);
+    return entries.map((entry) => {
+      if (isMalformed(entry)) {
+        const { kind, namespace, name, version, status } = entry.coords;
+        return { malformed: true, kind, namespace, name, version, status };
+      }
+      return { malformed: false, record: entry };
+    });
   }
 
   /** Load every record matching `filter` as an entry that is either a parsed

--- a/cdk/src/handlers/shared/registry/agent-registry-client.ts
+++ b/cdk/src/handlers/shared/registry/agent-registry-client.ts
@@ -56,6 +56,7 @@ import {
   RegistryRecordMalformedError,
   RegistryResolutionError,
   type ListFilter,
+  type MalformedReason,
   type PublishInput,
   type RegistryBrowseEntry,
   type RegistryRecord,
@@ -91,8 +92,9 @@ interface RecordCoords {
   readonly status: RegistryStatus;
 }
 
-/** A record whose envelope is readable but whose descriptor payload (SKILL.md
- *  frontmatter) failed to parse. Identity comes from the envelope, so the read
+/** A record whose envelope is readable but whose descriptor payload failed to
+ *  parse — any {@link MalformedReason}: SKILL.md frontmatter, an `x-abca-runtime`
+ *  value, or a CUSTOM/MCP JSON body. Identity comes from the envelope, so the read
  *  paths can skip it (browse) or reject it (resolve/getRecord) precisely,
  *  without trusting the erased payload (#791). */
 interface MalformedRecordEntry {
@@ -208,15 +210,34 @@ function parseSkillFrontmatter(skillMd: string): Record<string, unknown> {
       err,
     );
   }
-  return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
-    ? (parsed as Record<string, unknown>)
-    : {};
+  // An empty block (`---\n\n---`) is a record legitimately without frontmatter.
+  if (parsed === null || parsed === undefined) return {};
+  // A block that parses to a non-mapping (a sequence `- a\n- b`, or a bare scalar)
+  // is corrupt: collapsing it to `{}` would erase the publisher/runtime and let
+  // `show`/`list` surface it as an ordinary healthy record while attribution is
+  // silently gone. Reject it as MALFORMED, same as an unparseable block (#791).
+  if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new RegistryRecordMalformedError(
+      'MALFORMED_FRONTMATTER',
+      'SKILL.md frontmatter is not a mapping',
+    );
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/** Read a publisher (Cognito sub) field. Absent stays absent, but a *present but
+ *  wrong-typed* value (`123`, `["sub"]`) is a MALFORMED descriptor — coercing it
+ *  to `undefined` would silently erase attribution while the record stays
+ *  APPROVED and loadable, which is #791's vulnerability verbatim. */
+function readPublisherField(value: unknown, reason: MalformedReason): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === 'string') return value;
+  throw new RegistryRecordMalformedError(reason, 'publisher field is present but not a string');
 }
 
 /** Recover the publisher (Cognito sub) from the parsed SKILL.md frontmatter. */
 function parseSkillPublisher(skillMd: string): string | undefined {
-  const v = parseSkillFrontmatter(skillMd)[PUBLISHER_FM_KEY];
-  return typeof v === 'string' ? v : undefined;
+  return readPublisherField(parseSkillFrontmatter(skillMd)[PUBLISHER_FM_KEY], 'MALFORMED_FRONTMATTER');
 }
 
 /** Recover the ABCA runtime payload from a SKILL.md's `x-abca-runtime`
@@ -248,12 +269,18 @@ function parseSkillRuntime(skillMd: string): unknown {
   }
 }
 
-/** JSON.parse a descriptor body, boxing a parse failure as a MALFORMED marker
- *  (rather than a raw SyntaxError) so a corrupt CUSTOM/MCP body funnels through
- *  the same skip/reject read paths as bad SKILL.md frontmatter (#791). */
+/** JSON.parse a descriptor body into an object, boxing any failure as a MALFORMED
+ *  marker (rather than a raw SyntaxError/TypeError) so a corrupt CUSTOM/MCP body
+ *  funnels through the same skip/reject read paths as bad SKILL.md frontmatter
+ *  (#791). `JSON.parse` succeeds on non-objects too (`"null"`, `"[1,2]"`, `"123"`,
+ *  `"\"s\""`), and the callers immediately dereference the result — so a
+ *  successful parse that is not a plain object is rejected here rather than
+ *  crashing the next line with an unboxed `TypeError` that would escape `resolve`
+ *  as an opaque 500 and take down the whole namespace listing (#837 review). */
 function parseDescriptorJson(data: string, what: string): Record<string, unknown> {
+  let parsed: unknown;
   try {
-    return JSON.parse(data);
+    parsed = JSON.parse(data);
   } catch (err) {
     throw new RegistryRecordMalformedError(
       'MALFORMED_DESCRIPTOR',
@@ -261,6 +288,13 @@ function parseDescriptorJson(data: string, what: string): Record<string, unknown
       err,
     );
   }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new RegistryRecordMalformedError(
+      'MALFORMED_DESCRIPTOR',
+      `${what} is not a JSON object`,
+    );
+  }
+  return parsed as Record<string, unknown>;
 }
 
 export interface AgentRegistryClientOptions {
@@ -299,8 +333,23 @@ export class AgentRegistryClient implements RegistryClient {
     const useCustom = input.custom || !(input.kind in NATIVE_RECORD_TYPE_BY_KIND);
     const name = this.encodeName(input.kind, input.namespace, input.name);
 
-    // Immutability: reject a re-publish of the same coordinates.
-    const existing = await this.getRecord(input.kind, input.namespace, input.name, input.version);
+    // Immutability: reject a re-publish of the same coordinates. `getRecord`
+    // throws RegistryRecordMalformedError when a corrupt record already occupies
+    // them — that is still an occupied slot, so treat it as a conflict (409) with
+    // a corruption hint rather than letting it fall through to an opaque 500 that
+    // names neither the conflict nor the corruption (#837 review).
+    let existing: RegistryRecord | null;
+    try {
+      existing = await this.getRecord(input.kind, input.namespace, input.name, input.version);
+    } catch (err) {
+      if (err instanceof RegistryRecordMalformedError) {
+        throw new ConflictException({
+          message: `record ${name}@${input.version} already exists but its descriptor is malformed (${err.reason}); delete it before republishing`,
+          $metadata: {},
+        });
+      }
+      throw err;
+    }
     if (existing) {
       throw new ConflictException({
         message: `record ${name}@${input.version} already exists`,
@@ -492,10 +541,26 @@ export class AgentRegistryClient implements RegistryClient {
     // publisher/runtime were erased. Reject rather than trust an empty payload
     // or silently pick a different version (#791).
     if (isMalformed(winner)) {
+      // Keep the parser text (which can echo a fragment of the raw descriptor —
+      // a token in a `url` query string, an `Authorization` header value) out of
+      // the client-facing 422 body: resolve/list/show are open to any
+      // authenticated caller (REGISTRY.md §10), and the resolve handler returns
+      // this message verbatim, bypassing `redactRuntimeForResponse`. Surface only
+      // the coordinates + the `MalformedReason` discriminator; log the detail for
+      // the operator (#837 review).
+      logger.error('resolve rejected a malformed winner', {
+        recordId: winner.recordId,
+        kind: winner.coords.kind,
+        namespace: winner.coords.namespace,
+        name: winner.coords.name,
+        version: winner.coords.version,
+        reason: winner.error.reason,
+        error: winner.error.message,
+      });
       throw new RegistryResolutionError(
         'MALFORMED',
         refStr,
-        `resolved ${winner.coords.kind}/${winner.coords.namespace}/${winner.coords.name}@${winner.coords.version} has a malformed descriptor (${winner.error.reason}): ${winner.error.message}`,
+        `resolved ${winner.coords.kind}/${winner.coords.namespace}/${winner.coords.name}@${winner.coords.version} has a malformed descriptor (${winner.error.reason})`,
       );
     }
     // Fail closed: an otherwise-resolvable record whose runtime payload is
@@ -622,7 +687,7 @@ export class AgentRegistryClient implements RegistryClient {
         runtime: body.runtime as RuntimePayload,
         storageMode: 'custom',
         discovery: (body.discovery ?? {}) as Record<string, unknown>,
-        publisher: typeof body.publisher === 'string' ? body.publisher : undefined,
+        publisher: readPublisherField(body.publisher, 'MALFORMED_DESCRIPTOR'),
       };
     }
     if (raw.recordType === 'SKILL') {
@@ -642,12 +707,11 @@ export class AgentRegistryClient implements RegistryClient {
     const meta = body._meta && typeof body._meta === 'object' && !Array.isArray(body._meta)
       ? (body._meta as Record<string, unknown>)
       : {};
-    const publisher = meta[PUBLISHER_META_KEY];
     return {
       runtime: meta[RUNTIME_META_KEY] as RuntimePayload,
       storageMode: 'native',
       discovery: body,
-      publisher: typeof publisher === 'string' ? publisher : undefined,
+      publisher: readPublisherField(meta[PUBLISHER_META_KEY], 'MALFORMED_DESCRIPTOR'),
     };
   }
 

--- a/cdk/src/handlers/shared/registry/agent-registry-client.ts
+++ b/cdk/src/handlers/shared/registry/agent-registry-client.ts
@@ -53,6 +53,7 @@ import {
   PUBLISHER_META_KEY,
   RUNTIME_META_KEY,
   RegistryPublishIncompleteError,
+  RegistryRecordMalformedError,
   RegistryResolutionError,
   type ListFilter,
   type PublishInput,
@@ -77,6 +78,46 @@ function isNonEmptyRuntime(runtime: unknown): boolean {
     !Array.isArray(runtime) &&
     Object.keys(runtime as Record<string, unknown>).length > 0
   );
+}
+
+/** Coordinates read straight from the record envelope (name/version/status),
+ *  which stay readable even when the descriptor payload does not parse. */
+interface RecordCoords {
+  readonly kind: string;
+  readonly namespace: string;
+  readonly name: string;
+  readonly version: string;
+  readonly status: RegistryStatus;
+}
+
+/** A record whose envelope is readable but whose descriptor payload (SKILL.md
+ *  frontmatter) failed to parse. Identity comes from the envelope, so the read
+ *  paths can skip it (browse) or reject it (resolve/getRecord) precisely,
+ *  without trusting the erased payload (#791). */
+interface MalformedRecordEntry {
+  readonly malformed: true;
+  readonly coords: RecordCoords;
+  readonly recordId: string;
+  readonly error: RegistryRecordMalformedError;
+}
+
+type RecordEntry = RegistryRecord | MalformedRecordEntry;
+
+function isMalformed(entry: RecordEntry): entry is MalformedRecordEntry {
+  return (entry as MalformedRecordEntry).malformed === true;
+}
+
+/** Coordinates of an entry regardless of whether it parsed. */
+function entryCoords(entry: RecordEntry): RecordCoords {
+  return isMalformed(entry)
+    ? entry.coords
+    : {
+      kind: entry.kind,
+      namespace: entry.namespace,
+      name: entry.name,
+      version: entry.version,
+      status: entry.status,
+    };
 }
 
 /** Kinds that map onto a native Agent Registry record type. */
@@ -143,21 +184,31 @@ function buildSkillMd(input: {
 }
 
 /** Extract and YAML-parse the frontmatter block (between the first `---`/`---`
- *  pair) into an object. Returns {} when there is no valid block. Parsing the
- *  whole block as one document (rather than a per-line regex) is what makes key
- *  injection via a newline-bearing value impossible — a duplicate key is a YAML
- *  error, and a value's newline stays inside that value. */
+ *  pair) into an object. Returns {} when there is *no* block at all (a record
+ *  legitimately without frontmatter). A block that is present but fails to parse
+ *  throws {@link RegistryRecordMalformedError} — it must NOT collapse to `{}`,
+ *  which would erase the publisher/runtime and make a malformed record look
+ *  empty (#791). Parsing the whole block as one document (rather than a per-line
+ *  regex) is what makes key injection via a newline-bearing value impossible — a
+ *  duplicate key is a YAML error, and a value's newline stays inside that value;
+ *  surfacing that error (rather than swallowing it) is what keeps the injection
+ *  defense live. */
 function parseSkillFrontmatter(skillMd: string): Record<string, unknown> {
   const m = skillMd.match(/^---\n([\s\S]*?)\n---/);
   if (!m) return {};
+  let parsed: unknown;
   try {
-    const parsed = yaml.load(m[1], { json: true });
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : {};
-  } catch {
-    return {}; // nosemgrep: ts-silent-success-masking -- invalid YAML becomes an unreadable payload
+    parsed = yaml.load(m[1], { json: true });
+  } catch (err) {
+    throw new RegistryRecordMalformedError(
+      'MALFORMED_FRONTMATTER',
+      `SKILL.md frontmatter is not valid YAML: ${err instanceof Error ? err.message : String(err)}`,
+      err,
+    );
   }
+  return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : {};
 }
 
 /** Recover the publisher (Cognito sub) from the parsed SKILL.md frontmatter. */
@@ -270,9 +321,13 @@ export class AgentRegistryClient implements RegistryClient {
         );
       }
 
-      const record = await this.getRecordById(recordId);
-      if (!record) throw new Error(`published record ${recordId} not readable after write`);
-      return record;
+      const entry = await this.loadRecordById(recordId);
+      if (!entry) throw new Error(`published record ${recordId} not readable after write`);
+      // The record we just serialized should always parse; if it doesn't, the
+      // write produced a corrupt descriptor — surface it (the catch below wraps
+      // it as a stranded-record error) rather than returning it.
+      if (isMalformed(entry)) throw entry.error;
+      return entry;
     } catch (err) {
       logger.error('registry publish incomplete — partial record stranded', {
         recordId,
@@ -299,16 +354,48 @@ export class AgentRegistryClient implements RegistryClient {
   ): Promise<RegistryRecord | null> {
     // Agent Registry keys records by opaque id, not our coordinates, and List is
     // eventually consistent — so scan the (small) record set and match.
-    const records = await this.listRecords({ kind, namespace });
-    return records.find((r) => r.name === name && r.version === version) ?? null;
+    const entries = await this.loadEntries({ kind, namespace });
+    const match = entries.find(
+      (e) => entryCoords(e).name === name && entryCoords(e).version === version,
+    );
+    if (!match) return null;
+    // Fail closed on the targeted record: a malformed frontmatter erased its
+    // publisher/runtime, so hand back the parse failure rather than a record
+    // with silently-dropped attribution (#791).
+    if (isMalformed(match)) throw match.error;
+    return match;
   }
 
   async listRecords(filter?: ListFilter): Promise<readonly RegistryRecord[]> {
-    // O(n): List + one GetRegistryRecord per summary, and every read
-    // path (resolve/show/getRecord) funnels through here. Fine at MVP catalog
-    // sizes; revisit with a secondary coordinate index if large catalogs make
-    // the per-record round trips material.
+    // Browse tolerates a poisoned record: skip a malformed one (with a loud
+    // warning) so one corrupt SKILL.md can't break listing an entire namespace.
+    // The trust-critical paths (resolve/getRecord) still reject it precisely.
+    const entries = await this.loadEntries(filter);
     const out: RegistryRecord[] = [];
+    for (const entry of entries) {
+      if (isMalformed(entry)) {
+        logger.warn('Skipping malformed registry record during list', {
+          record_id: entry.recordId,
+          kind: entry.coords.kind,
+          namespace: entry.coords.namespace,
+          name: entry.coords.name,
+          version: entry.coords.version,
+          error: entry.error.message,
+        });
+        continue;
+      }
+      out.push(entry);
+    }
+    return out;
+  }
+
+  /** Load every record matching `filter` as an entry that is either a parsed
+   *  record or a malformed marker. O(n): List + one GetRegistryRecord per
+   *  summary, and every read path (resolve/show/getRecord) funnels through here.
+   *  Fine at MVP catalog sizes; revisit with a secondary coordinate index if
+   *  large catalogs make the per-record round trips material. */
+  private async loadEntries(filter?: ListFilter): Promise<RecordEntry[]> {
+    const out: RecordEntry[] = [];
     let nextToken: string | undefined;
     do {
       const page = await this.client.send(
@@ -324,8 +411,8 @@ export class AgentRegistryClient implements RegistryClient {
         if (filter?.namespace && decoded.namespace !== filter.namespace) continue;
         const recordId = summary.recordArn ? this.idFromArn(summary.recordArn) : summary.recordId;
         if (!recordId) continue;
-        const full = await this.getRecordById(recordId);
-        if (full) out.push(full);
+        const entry = await this.loadRecordById(recordId);
+        if (entry) out.push(entry);
       }
       nextToken = page.nextToken;
     } while (nextToken);
@@ -336,15 +423,19 @@ export class AgentRegistryClient implements RegistryClient {
 
   async resolve(ref: ParsedRef): Promise<ResolvedAsset> {
     const refStr = `registry://${ref.kind}/${ref.namespace}/${ref.name}@${ref.constraint.raw}`;
-    const all = await this.listRecords({ kind: ref.kind, namespace: ref.namespace });
-    const forName = all.filter((r) => r.name === ref.name);
+    // Consider malformed entries as candidates too: a malformed record still has
+    // a readable version/status from its envelope, so if it is the winning
+    // version we must reject it rather than silently downgrade to a lower one.
+    const all = await this.loadEntries({ kind: ref.kind, namespace: ref.namespace });
+    const forName = all.filter((e) => entryCoords(e).name === ref.name);
 
     // Only APPROVED / DEPRECATED are resolution candidates.
-    const candidates = forName.filter(
-      (r) => r.status === 'APPROVED' || r.status === 'DEPRECATED',
-    );
+    const candidates = forName.filter((e) => {
+      const status = entryCoords(e).status;
+      return status === 'APPROVED' || status === 'DEPRECATED';
+    });
     const winningVersion = selectHighest(
-      candidates.map((r) => r.version),
+      candidates.map((e) => entryCoords(e).version),
       ref.constraint,
     );
     if (!winningVersion) {
@@ -354,7 +445,17 @@ export class AgentRegistryClient implements RegistryClient {
         `no approved version of ${ref.kind}/${ref.namespace}/${ref.name} satisfies ${ref.constraint.raw}`,
       );
     }
-    const winner = candidates.find((r) => r.version === winningVersion)!;
+    const winner = candidates.find((e) => entryCoords(e).version === winningVersion)!;
+    // Fail closed: the resolved winner's frontmatter is unparseable, so its
+    // publisher/runtime were erased. Reject rather than trust an empty payload
+    // or silently pick a different version (#791).
+    if (isMalformed(winner)) {
+      throw new RegistryResolutionError(
+        'MALFORMED',
+        refStr,
+        `resolved ${winner.coords.kind}/${winner.coords.namespace}/${winner.coords.name}@${winner.coords.version} has malformed frontmatter: ${winner.error.message}`,
+      );
+    }
     // Fail closed: an otherwise-resolvable record whose runtime payload is
     // empty/unreadable must NOT resolve to `{}` — that would let a task run with
     // a missing/substituted asset while the audit claims the pin was honored
@@ -423,7 +524,7 @@ export class AgentRegistryClient implements RegistryClient {
     );
   }
 
-  private async getRecordById(recordId: string): Promise<RegistryRecord | null> {
+  private async loadRecordById(recordId: string): Promise<RecordEntry | null> {
     let raw;
     try {
       raw = await this.client.send(
@@ -436,17 +537,31 @@ export class AgentRegistryClient implements RegistryClient {
       throw err;
     }
     const decoded = this.decodeName(raw.name ?? '');
-    const { runtime, storageMode, discovery, publisher } = this.extractPayload(raw);
-    return {
+    const coords: RecordCoords = {
       kind: decoded.kind,
       namespace: decoded.namespace,
       name: decoded.name,
       version: raw.recordVersion ?? '',
       status: (raw.status ?? 'DRAFT') as RegistryStatus,
-      storageMode,
-      discovery,
-      runtime,
-      publisher,
+    };
+    let payload;
+    try {
+      payload = this.extractPayload(raw);
+    } catch (err) {
+      // A malformed descriptor payload keeps its envelope identity but its
+      // publisher/runtime are unreadable — carry it as a marker so the read
+      // paths can skip (browse) or reject (resolve/getRecord) it precisely.
+      if (err instanceof RegistryRecordMalformedError) {
+        return { malformed: true, coords, recordId, error: err };
+      }
+      throw err;
+    }
+    return {
+      ...coords,
+      storageMode: payload.storageMode,
+      discovery: payload.discovery,
+      runtime: payload.runtime,
+      publisher: payload.publisher,
       createdAt: raw.createdAt ? raw.createdAt.toISOString() : undefined,
     };
   }

--- a/cdk/src/handlers/shared/registry/agent-registry-client.ts
+++ b/cdk/src/handlers/shared/registry/agent-registry-client.ts
@@ -229,12 +229,38 @@ function parseSkillRuntime(skillMd: string): unknown {
   const raw = parseSkillFrontmatter(skillMd)[SKILL_RUNTIME_FM_KEY];
   if (typeof raw !== 'string') return {};
   // Legacy form: raw JSON (YAML has already unwrapped its single-quoting, so the
-  // value arrives starting with `{`). New form: base64-encoded JSON.
+  // value arrives starting with `{`). New form: base64-encoded JSON. A present
+  // but undecodable value must NOT slip out as a raw SyntaxError: box it as
+  // MALFORMED so `loadRecordById` carries it as a marker and the read paths
+  // skip/reject it precisely, exactly as they do for bad frontmatter (#791).
   const trimmed = raw.trim();
-  if (trimmed.startsWith('{')) {
-    return JSON.parse(trimmed);
+  try {
+    if (trimmed.startsWith('{')) {
+      return JSON.parse(trimmed);
+    }
+    return JSON.parse(Buffer.from(raw, 'base64').toString('utf-8'));
+  } catch (err) {
+    throw new RegistryRecordMalformedError(
+      'MALFORMED_RUNTIME',
+      `SKILL.md ${SKILL_RUNTIME_FM_KEY} is not decodable base64/JSON: ${err instanceof Error ? err.message : String(err)}`,
+      err,
+    );
   }
-  return JSON.parse(Buffer.from(raw, 'base64').toString('utf-8'));
+}
+
+/** JSON.parse a descriptor body, boxing a parse failure as a MALFORMED marker
+ *  (rather than a raw SyntaxError) so a corrupt CUSTOM/MCP body funnels through
+ *  the same skip/reject read paths as bad SKILL.md frontmatter (#791). */
+function parseDescriptorJson(data: string, what: string): Record<string, unknown> {
+  try {
+    return JSON.parse(data);
+  } catch (err) {
+    throw new RegistryRecordMalformedError(
+      'MALFORMED_DESCRIPTOR',
+      `${what} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      err,
+    );
+  }
 }
 
 export interface AgentRegistryClientOptions {
@@ -361,7 +387,7 @@ export class AgentRegistryClient implements RegistryClient {
       (e) => entryCoords(e).name === name && entryCoords(e).version === version,
     );
     if (!match) return null;
-    // Fail closed on the targeted record: a malformed frontmatter erased its
+    // Fail closed on the targeted record: a malformed descriptor erased its
     // publisher/runtime, so hand back the parse failure rather than a record
     // with silently-dropped attribution (#791).
     if (isMalformed(match)) throw match.error;
@@ -462,21 +488,21 @@ export class AgentRegistryClient implements RegistryClient {
       );
     }
     const winner = candidates.find((e) => entryCoords(e).version === winningVersion)!;
-    // Fail closed: the resolved winner's frontmatter is unparseable, so its
+    // Fail closed: the resolved winner's descriptor is unparseable, so its
     // publisher/runtime were erased. Reject rather than trust an empty payload
     // or silently pick a different version (#791).
     if (isMalformed(winner)) {
       throw new RegistryResolutionError(
         'MALFORMED',
         refStr,
-        `resolved ${winner.coords.kind}/${winner.coords.namespace}/${winner.coords.name}@${winner.coords.version} has malformed frontmatter: ${winner.error.message}`,
+        `resolved ${winner.coords.kind}/${winner.coords.namespace}/${winner.coords.name}@${winner.coords.version} has a malformed descriptor (${winner.error.reason}): ${winner.error.message}`,
       );
     }
     // Fail closed: an otherwise-resolvable record whose runtime payload is
-    // empty/unreadable must NOT resolve to `{}` — that would let a task run with
-    // a missing/substituted asset while the audit claims the pin was honored
-    // (REGISTRY.md §8). A record can reach this state via an out-of-band write or
-    // a corrupt `_meta`/CUSTOM body that slipped past publish validation.
+    // empty must NOT resolve to `{}` — that would let a task run with a
+    // missing/substituted asset while the audit claims the pin was honored
+    // (REGISTRY.md §8). A record can reach this state via an out-of-band write;
+    // a corrupt descriptor is caught above as MALFORMED.
     if (!isNonEmptyRuntime(winner.runtime)) {
       throw new RegistryResolutionError(
         'REMOVED',
@@ -591,7 +617,7 @@ export class AgentRegistryClient implements RegistryClient {
     publisher?: string;
   } {
     if (raw.recordType === 'CUSTOM') {
-      const body = JSON.parse(raw.descriptors?.custom?.data ?? '{}');
+      const body = parseDescriptorJson(raw.descriptors?.custom?.data ?? '{}', 'CUSTOM record body');
       return {
         runtime: body.runtime as RuntimePayload,
         storageMode: 'custom',
@@ -612,13 +638,15 @@ export class AgentRegistryClient implements RegistryClient {
     }
     // MCP: JSON server.json with the runtime in a `_meta` block.
     const inline = raw.descriptors?.mcpServer?.data ?? '{}';
-    const body = JSON.parse(inline);
-    const meta = body._meta?.[RUNTIME_META_KEY];
-    const publisher = body._meta?.[PUBLISHER_META_KEY];
+    const body = parseDescriptorJson(inline, 'MCP server.json body');
+    const meta = body._meta && typeof body._meta === 'object' && !Array.isArray(body._meta)
+      ? (body._meta as Record<string, unknown>)
+      : {};
+    const publisher = meta[PUBLISHER_META_KEY];
     return {
-      runtime: meta as RuntimePayload,
+      runtime: meta[RUNTIME_META_KEY] as RuntimePayload,
       storageMode: 'native',
-      discovery: body as Record<string, unknown>,
+      discovery: body,
       publisher: typeof publisher === 'string' ? publisher : undefined,
     };
   }

--- a/cdk/src/handlers/shared/registry/client.ts
+++ b/cdk/src/handlers/shared/registry/client.ts
@@ -26,6 +26,7 @@ import type { ParsedRef } from './ref';
 import type {
   ListFilter,
   PublishInput,
+  RegistryBrowseEntry,
   RegistryRecord,
   ResolvedAsset,
 } from './types';
@@ -49,6 +50,14 @@ export interface RegistryClient {
 
   /** List records (optionally filtered by kind/namespace). */
   listRecords(filter?: ListFilter): Promise<readonly RegistryRecord[]>;
+
+  /**
+   * Like {@link listRecords} but includes malformed records as envelope-only
+   * markers instead of dropping them. `show` uses this so an asset whose only
+   * versions have corrupt descriptors surfaces (flagged) rather than 404-ing as
+   * if it did not exist (#791). `listRecords` stays the tolerant browse default.
+   */
+  listBrowseEntries(filter?: ListFilter): Promise<readonly RegistryBrowseEntry[]>;
 
   /**
    * Resolve a parsed ref to a single asset: gather candidate versions, rank by

--- a/cdk/src/handlers/shared/registry/types.ts
+++ b/cdk/src/handlers/shared/registry/types.ts
@@ -153,15 +153,29 @@ export class RegistryResolutionError extends Error {
   }
 }
 
+/** Which stage of descriptor decoding failed. Every arm is a *present but
+ *  unparseable* payload — the discriminator lets a reader tell YAML-frontmatter
+ *  corruption apart from a bad `x-abca-runtime` value or a non-JSON CUSTOM/MCP
+ *  body without re-inspecting the cause. */
+export type MalformedReason =
+  // MALFORMED_FRONTMATTER: SKILL.md frontmatter block failed to YAML-parse.
+  // MALFORMED_RUNTIME: `x-abca-runtime` value is not decodable base64/JSON.
+  // MALFORMED_DESCRIPTOR: CUSTOM or MCP descriptor body is not valid JSON.
+  | 'MALFORMED_FRONTMATTER'
+  | 'MALFORMED_RUNTIME'
+  | 'MALFORMED_DESCRIPTOR';
+
 /**
- * Raised when a record's descriptor payload is present but unparseable — e.g. a
- * SKILL.md frontmatter block that fails to YAML-parse. Distinct from an *absent*
- * record and from an *empty* runtime: a malformed payload must be rejected, not
- * silently collapsed to `{}`. Collapsing erases the publisher (attribution) and
- * runtime, making a malformed record indistinguishable from a legitimately empty
- * one and letting attacker-influenced input drop an audit-critical trust field
- * (#791). The frontmatter-injection defense itself (#664/#246 B1/B2) lives on
- * the *write* side — `buildSkillMd` emits every value through a YAML dumper that
+ * Raised when a record's descriptor payload is present but unparseable — a
+ * SKILL.md frontmatter block that fails to YAML-parse, an `x-abca-runtime` value
+ * that is not decodable base64/JSON, or a CUSTOM/MCP body that is not valid JSON
+ * (see {@link MalformedReason}). Distinct from an *absent* record and from an
+ * *empty* runtime: a malformed payload must be rejected, not silently collapsed
+ * to `{}`. Collapsing erases the publisher (attribution) and runtime, making a
+ * malformed record indistinguishable from a legitimately empty one and letting
+ * attacker-influenced input drop an audit-critical trust field (#791). The
+ * frontmatter-injection defense itself (#664/#246 B1/B2) lives on the *write*
+ * side — `buildSkillMd` emits every value through a YAML dumper that
  * quotes/escapes newlines, so no discovery field can smuggle a shadowing key;
  * surfacing a genuine parse failure here is about not masking corruption, not
  * about the injection defense. Mirrors `RegistryRecordMalformedError` in
@@ -169,7 +183,7 @@ export class RegistryResolutionError extends Error {
  */
 export class RegistryRecordMalformedError extends Error {
   constructor(
-    readonly reason: 'MALFORMED_FRONTMATTER',
+    readonly reason: MalformedReason,
     message: string,
     readonly cause?: unknown,
   ) {

--- a/cdk/src/handlers/shared/registry/types.ts
+++ b/cdk/src/handlers/shared/registry/types.ts
@@ -100,6 +100,23 @@ export interface RegistryRecord {
   readonly createdAt?: string;
 }
 
+/** A record as a browse surface (`show`) sees it: either fully parsed, or a
+ *  marker that a record exists at these coordinates but its descriptor payload
+ *  did not parse. The envelope coordinates (name/version/status) stay readable
+ *  even when the payload is corrupt, so `show` can surface the version — flagged
+ *  as malformed — instead of dropping it and 404-ing an asset whose only
+ *  versions are corrupt (#791). */
+export type RegistryBrowseEntry =
+  | { readonly malformed: false; readonly record: RegistryRecord }
+  | {
+    readonly malformed: true;
+    readonly kind: string;
+    readonly namespace: string;
+    readonly name: string;
+    readonly version: string;
+    readonly status: RegistryStatus;
+  };
+
 /** What the resolver hands back for one ref: enough to load the asset without the
  *  caller knowing where the bytes live. */
 export interface ResolvedAsset {
@@ -143,9 +160,11 @@ export class RegistryResolutionError extends Error {
  * silently collapsed to `{}`. Collapsing erases the publisher (attribution) and
  * runtime, making a malformed record indistinguishable from a legitimately empty
  * one and letting attacker-influenced input drop an audit-critical trust field
- * (#791). It also disarms the duplicate-key frontmatter-injection defense
- * (#664/#246 B1/B2), which relies on the YAML error surfacing rather than being
- * swallowed. Mirrors `RegistryRecordMalformedError` in
+ * (#791). The frontmatter-injection defense itself (#664/#246 B1/B2) lives on
+ * the *write* side — `buildSkillMd` emits every value through a YAML dumper that
+ * quotes/escapes newlines, so no discovery field can smuggle a shadowing key;
+ * surfacing a genuine parse failure here is about not masking corruption, not
+ * about the injection defense. Mirrors `RegistryRecordMalformedError` in
  * `agent/src/registry/client.py`.
  */
 export class RegistryRecordMalformedError extends Error {

--- a/cdk/src/handlers/shared/registry/types.ts
+++ b/cdk/src/handlers/shared/registry/types.ts
@@ -121,6 +121,7 @@ export interface ResolvedAssetBundle {
 export type ResolutionFailureReason =
   | 'NO_MATCHING_VERSION'
   | 'REMOVED'
+  | 'MALFORMED'
   | 'INVALID_CONSTRAINT'
   | 'INVALID_REGISTRY_REF';
 
@@ -132,6 +133,29 @@ export class RegistryResolutionError extends Error {
   ) {
     super(message);
     this.name = 'RegistryResolutionError';
+  }
+}
+
+/**
+ * Raised when a record's descriptor payload is present but unparseable — e.g. a
+ * SKILL.md frontmatter block that fails to YAML-parse. Distinct from an *absent*
+ * record and from an *empty* runtime: a malformed payload must be rejected, not
+ * silently collapsed to `{}`. Collapsing erases the publisher (attribution) and
+ * runtime, making a malformed record indistinguishable from a legitimately empty
+ * one and letting attacker-influenced input drop an audit-critical trust field
+ * (#791). It also disarms the duplicate-key frontmatter-injection defense
+ * (#664/#246 B1/B2), which relies on the YAML error surfacing rather than being
+ * swallowed. Mirrors `RegistryRecordMalformedError` in
+ * `agent/src/registry/client.py`.
+ */
+export class RegistryRecordMalformedError extends Error {
+  constructor(
+    readonly reason: 'MALFORMED_FRONTMATTER',
+    message: string,
+    readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'RegistryRecordMalformedError';
   }
 }
 

--- a/cdk/src/handlers/shared/registry/types.ts
+++ b/cdk/src/handlers/shared/registry/types.ts
@@ -174,7 +174,7 @@ export type MalformedReason =
  * to `{}`. Collapsing erases the publisher (attribution) and runtime, making a
  * malformed record indistinguishable from a legitimately empty one and letting
  * attacker-influenced input drop an audit-critical trust field (#791). The
- * frontmatter-injection defense itself (#664/#246 B1/B2) lives on the *write*
+ * frontmatter-injection defense itself (#246 review B1/B2) lives on the *write*
  * side — `buildSkillMd` emits every value through a YAML dumper that
  * quotes/escapes newlines, so no discovery field can smuggle a shadowing key;
  * surfacing a genuine parse failure here is about not masking corruption, not

--- a/cdk/src/handlers/shared/types.ts
+++ b/cdk/src/handlers/shared/types.ts
@@ -88,6 +88,10 @@ export type RegistryVersionSummary = {
   readonly status: string;
   readonly created_at: string | null;
   readonly publisher: string | null;
+  /** True when the record's descriptor payload failed to parse — its publisher
+   *  and created_at are unrecoverable (erased), so they read `null`. Surfaced
+   *  rather than hidden so a corrupt version is visible to operators (#791). */
+  readonly malformed?: boolean;
 };
 
 /** `GET /registry/records/{kind}/{namespace}/{name}` response — one asset's

--- a/cdk/src/handlers/shared/types.ts
+++ b/cdk/src/handlers/shared/types.ts
@@ -88,9 +88,11 @@ export type RegistryVersionSummary = {
   readonly status: string;
   readonly created_at: string | null;
   readonly publisher: string | null;
-  /** True when the record's descriptor payload failed to parse — its publisher
-   *  and created_at are unrecoverable (erased), so they read `null`. Surfaced
-   *  rather than hidden so a corrupt version is visible to operators (#791). */
+  /** True when the record's descriptor payload failed to parse. `publisher` lives
+   *  in the erased payload so it is unrecoverable (reads `null`); `created_at` is
+   *  envelope data and is nulled only by the `show` marker's convention, not
+   *  because it is lost. Surfaced rather than hidden so a corrupt version is
+   *  visible to operators (#791). */
   readonly malformed?: boolean;
 };
 

--- a/cdk/test/handlers/registry-handlers.test.ts
+++ b/cdk/test/handlers/registry-handlers.test.ts
@@ -34,6 +34,7 @@ const mockClient: jest.Mocked<RegistryClient> = {
   publish: mockPublish,
   getRecord: jest.fn(),
   listRecords: jest.fn(),
+  listBrowseEntries: jest.fn(),
   resolve: jest.fn(),
 };
 jest.mock('../../src/handlers/shared/registry/factory', () => {
@@ -330,19 +331,32 @@ describe('registry-list handler', () => {
 
 describe('registry-show handler', () => {
   test('404 when the asset has no versions', async () => {
-    mockClient.listRecords.mockResolvedValue([]);
+    mockClient.listBrowseEntries.mockResolvedValue([]);
     const res = await showHandler(makeEvent({ httpMethod: 'GET', pathParameters: { kind: 'mcp_server', namespace: 'acme', name: 'nope' } }));
     expect(res.statusCode).toBe(404);
   });
 
   test('200 lists versions highest-first', async () => {
-    mockClient.listRecords.mockResolvedValue([
-      { kind: 'mcp_server', namespace: 'acme', name: 'pdf-tools', version: '1.0.0', status: 'DEPRECATED', storageMode: 'native', discovery: {}, runtime: {} as never },
-      { kind: 'mcp_server', namespace: 'acme', name: 'pdf-tools', version: '1.2.0', status: 'APPROVED', storageMode: 'native', discovery: {}, runtime: {} as never },
+    mockClient.listBrowseEntries.mockResolvedValue([
+      { malformed: false, record: { kind: 'mcp_server', namespace: 'acme', name: 'pdf-tools', version: '1.0.0', status: 'DEPRECATED', storageMode: 'native', discovery: {}, runtime: {} as never } },
+      { malformed: false, record: { kind: 'mcp_server', namespace: 'acme', name: 'pdf-tools', version: '1.2.0', status: 'APPROVED', storageMode: 'native', discovery: {}, runtime: {} as never } },
     ]);
     const res = await showHandler(makeEvent({ httpMethod: 'GET', pathParameters: { kind: 'mcp_server', namespace: 'acme', name: 'pdf-tools' } }));
     expect(res.statusCode).toBe(200);
     const versions = JSON.parse(res.body).data.versions;
     expect(versions[0].version).toBe('1.2.0');
+  });
+
+  test('surfaces a malformed-only asset (flagged) instead of 404-ing it', async () => {
+    // An asset whose only version has a corrupt descriptor must not masquerade
+    // as absent — the operator needs to see the corruption exists (#791).
+    mockClient.listBrowseEntries.mockResolvedValue([
+      { malformed: true, kind: 'skill', namespace: 'acme', name: 'readme-helper', version: '1.0.0', status: 'APPROVED' },
+    ]);
+    const res = await showHandler(makeEvent({ httpMethod: 'GET', pathParameters: { kind: 'skill', namespace: 'acme', name: 'readme-helper' } }));
+    expect(res.statusCode).toBe(200);
+    const versions = JSON.parse(res.body).data.versions;
+    expect(versions).toHaveLength(1);
+    expect(versions[0]).toMatchObject({ version: '1.0.0', status: 'APPROVED', malformed: true, publisher: null, created_at: null });
   });
 });

--- a/cdk/test/handlers/shared/agent-registry-client.test.ts
+++ b/cdk/test/handlers/shared/agent-registry-client.test.ts
@@ -26,7 +26,11 @@ import {
 } from '@aws-sdk/client-agent-registry-control';
 import { AgentRegistryClient } from '../../../src/handlers/shared/registry/agent-registry-client';
 import { parseRef } from '../../../src/handlers/shared/registry/ref';
-import { RegistryPublishIncompleteError, RegistryResolutionError } from '../../../src/handlers/shared/registry/types';
+import {
+  RegistryPublishIncompleteError,
+  RegistryRecordMalformedError,
+  RegistryResolutionError,
+} from '../../../src/handlers/shared/registry/types';
 
 const RUNTIME_META_KEY = 'dev.abca.runtime';
 
@@ -435,6 +439,94 @@ describe('AgentRegistryClient', () => {
     if (!parsed.ok) throw new Error('fixture ref should parse');
     await expect(client.resolve(parsed.ref)).rejects.toMatchObject({ reason: 'REMOVED' });
     await expect(client.resolve(parsed.ref)).rejects.toBeInstanceOf(RegistryResolutionError);
+  });
+
+  // A SKILL.md whose frontmatter block is present but not valid YAML (unterminated
+  // flow sequence). A parse failure must reject the record, not collapse to `{}` —
+  // which would erase the publisher (attribution) and runtime (#791).
+  const seedMalformedSkill = (fake: FakeClient, status = 'APPROVED'): string =>
+    fake.seed({
+      name: 'skill/acme/readme-helper',
+      recordType: 'SKILL',
+      descriptors: {
+        agentSkillsDefinition: {
+          additionalData: { skillMd: { data: '---\nname: acme-readme-helper\nx-abca-runtime: [1, 2\n---\n# body' } },
+        },
+      },
+      recordVersion: '1.0.0',
+      status,
+    });
+
+  test('resolve fails closed (MALFORMED) when the winning record has unparseable frontmatter', async () => {
+    const fake = new FakeClient();
+    const client = makeClient(fake);
+    seedMalformedSkill(fake);
+    const parsed = parseRef('registry://skill/acme/readme-helper@1.0.0');
+    if (!parsed.ok) throw new Error('fixture ref should parse');
+    await expect(client.resolve(parsed.ref)).rejects.toMatchObject({ reason: 'MALFORMED' });
+    await expect(client.resolve(parsed.ref)).rejects.toBeInstanceOf(RegistryResolutionError);
+  });
+
+  test('resolve rejects a malformed winner rather than downgrading to a lower valid version', async () => {
+    const fake = new FakeClient();
+    const client = makeClient(fake);
+    // A valid lower version exists, but the highest matching version is malformed.
+    // Silently picking the lower one would mask that the pinned version is corrupt.
+    fake.seed({
+      name: 'skill/acme/readme-helper',
+      recordType: 'SKILL',
+      descriptors: {
+        agentSkillsDefinition: {
+          additionalData: {
+            skillMd: {
+              data:
+                `---\nname: acme-readme-helper\nx-abca-runtime: ${Buffer.from(JSON.stringify({ prompt_fragment: 'ok' })).toString('base64')}\n---\n# body`,
+            },
+          },
+        },
+      },
+      recordVersion: '1.0.0',
+      status: 'APPROVED',
+    });
+    fake.seed({
+      name: 'skill/acme/readme-helper',
+      recordType: 'SKILL',
+      descriptors: {
+        agentSkillsDefinition: {
+          additionalData: { skillMd: { data: '---\nname: acme-readme-helper\nx-abca-runtime: [1, 2\n---\n# body' } },
+        },
+      },
+      recordVersion: '1.1.0',
+      status: 'APPROVED',
+    });
+    const parsed = parseRef('registry://skill/acme/readme-helper@^1.0.0');
+    if (!parsed.ok) throw new Error('fixture ref should parse');
+    await expect(client.resolve(parsed.ref)).rejects.toMatchObject({ reason: 'MALFORMED' });
+  });
+
+  test('getRecord throws RegistryRecordMalformedError for a malformed target record', async () => {
+    const fake = new FakeClient();
+    const client = makeClient(fake);
+    seedMalformedSkill(fake, 'DRAFT');
+    await expect(client.getRecord('skill', 'acme', 'readme-helper', '1.0.0')).rejects.toBeInstanceOf(
+      RegistryRecordMalformedError,
+    );
+  });
+
+  test('listRecords skips a malformed record but returns the healthy ones', async () => {
+    const fake = new FakeClient();
+    const client = makeClient(fake);
+    seedMalformedSkill(fake);
+    fake.seed({
+      name: 'mcp_server/acme/pdf-tools',
+      recordType: 'MCP',
+      descriptors: { mcpServer: { data: JSON.stringify({ name: 'acme/pdf-tools', version: '1.0.0', _meta: { [RUNTIME_META_KEY]: { transport: 'http', url: 'https://x' } } }) } },
+      recordVersion: '1.0.0',
+      status: 'APPROVED',
+    });
+    const records = await client.listRecords();
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({ kind: 'mcp_server', name: 'pdf-tools' });
   });
 
   test('publish (native MCP) preserves a caller-supplied discovery._meta alongside ABCA keys', async () => {

--- a/cdk/test/handlers/shared/agent-registry-client.test.ts
+++ b/cdk/test/handlers/shared/agent-registry-client.test.ts
@@ -529,6 +529,39 @@ describe('AgentRegistryClient', () => {
     expect(records[0]).toMatchObject({ kind: 'mcp_server', name: 'pdf-tools' });
   });
 
+  test('listBrowseEntries keeps a malformed record as an envelope-only marker', async () => {
+    // Unlike listRecords, browse entries retain the malformed record so `show`
+    // can surface a corrupt version instead of 404-ing the asset (#791).
+    const fake = new FakeClient();
+    const client = makeClient(fake);
+    seedMalformedSkill(fake);
+    const entries = await client.listBrowseEntries({ kind: 'skill', namespace: 'acme' });
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      malformed: true,
+      kind: 'skill',
+      namespace: 'acme',
+      name: 'readme-helper',
+      version: '1.0.0',
+      status: 'APPROVED',
+    });
+  });
+
+  test('listBrowseEntries wraps a healthy record under { malformed: false, record }', async () => {
+    const fake = new FakeClient();
+    const client = makeClient(fake);
+    fake.seed({
+      name: 'mcp_server/acme/pdf-tools',
+      recordType: 'MCP',
+      descriptors: { mcpServer: { data: JSON.stringify({ name: 'acme/pdf-tools', version: '1.0.0', _meta: { [RUNTIME_META_KEY]: { transport: 'http', url: 'https://x' } } }) } },
+      recordVersion: '1.0.0',
+      status: 'APPROVED',
+    });
+    const entries = await client.listBrowseEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ malformed: false, record: { kind: 'mcp_server', name: 'pdf-tools' } });
+  });
+
   test('publish (native MCP) preserves a caller-supplied discovery._meta alongside ABCA keys', async () => {
     const fake = new FakeClient();
     const client = makeClient(fake);

--- a/cdk/test/handlers/shared/agent-registry-client.test.ts
+++ b/cdk/test/handlers/shared/agent-registry-client.test.ts
@@ -504,6 +504,104 @@ describe('AgentRegistryClient', () => {
     await expect(client.resolve(parsed.ref)).rejects.toMatchObject({ reason: 'MALFORMED' });
   });
 
+  // Corruption past the frontmatter YAML: the block parses as valid YAML, but the
+  // descriptor value inside is undecodable. These must classify as MALFORMED too —
+  // #791's browse-tolerance / show-flagging / resolve-reject guarantees have to
+  // hold for every descriptor parse point, not just the YAML block (PR #837 review).
+  const seedCorruptRuntimeSkill = (fake: FakeClient, status = 'APPROVED'): string =>
+    fake.seed({
+      name: 'skill/acme/readme-helper',
+      recordType: 'SKILL',
+      descriptors: {
+        agentSkillsDefinition: {
+          // Valid YAML frontmatter, but x-abca-runtime base64-decodes to a
+          // non-JSON string ("not json"), so JSON.parse throws.
+          additionalData: {
+            skillMd: {
+              data: `---\nname: acme-readme-helper\nx-abca-runtime: ${Buffer.from('not json').toString('base64')}\n---\n# body`,
+            },
+          },
+        },
+      },
+      recordVersion: '1.0.0',
+      status,
+    });
+
+  const seedCorruptCustom = (fake: FakeClient, status = 'APPROVED'): string =>
+    fake.seed({
+      name: 'cedar_policy_module/acme/permit',
+      recordType: 'CUSTOM',
+      descriptors: { custom: { data: 'not json{' } },
+      recordVersion: '1.0.0',
+      status,
+    });
+
+  const seedCorruptMcp = (fake: FakeClient, status = 'APPROVED'): string =>
+    fake.seed({
+      name: 'mcp_server/acme/pdf-tools',
+      recordType: 'MCP',
+      descriptors: { mcpServer: { data: '{bad json' } },
+      recordVersion: '1.0.0',
+      status,
+    });
+
+  test('resolve fails closed (MALFORMED) when x-abca-runtime is undecodable base64/JSON', async () => {
+    const fake = new FakeClient();
+    const client = makeClient(fake);
+    seedCorruptRuntimeSkill(fake);
+    const parsed = parseRef('registry://skill/acme/readme-helper@1.0.0');
+    if (!parsed.ok) throw new Error('fixture ref should parse');
+    await expect(client.resolve(parsed.ref)).rejects.toMatchObject({ reason: 'MALFORMED' });
+    await expect(client.resolve(parsed.ref)).rejects.toBeInstanceOf(RegistryResolutionError);
+  });
+
+  test('resolve fails closed (MALFORMED) when a CUSTOM body is not valid JSON', async () => {
+    const fake = new FakeClient();
+    const client = makeClient(fake);
+    seedCorruptCustom(fake);
+    const parsed = parseRef('registry://cedar_policy_module/acme/permit@1.0.0');
+    if (!parsed.ok) throw new Error('fixture ref should parse');
+    await expect(client.resolve(parsed.ref)).rejects.toMatchObject({ reason: 'MALFORMED' });
+  });
+
+  test('resolve fails closed (MALFORMED) when an MCP server.json is not valid JSON', async () => {
+    const fake = new FakeClient();
+    const client = makeClient(fake);
+    seedCorruptMcp(fake);
+    const parsed = parseRef('registry://mcp_server/acme/pdf-tools@1.0.0');
+    if (!parsed.ok) throw new Error('fixture ref should parse');
+    await expect(client.resolve(parsed.ref)).rejects.toMatchObject({ reason: 'MALFORMED' });
+  });
+
+  test('listRecords tolerates a corrupt CUSTOM/MCP/runtime record (skips, does not abort the namespace)', async () => {
+    const fake = new FakeClient();
+    const client = makeClient(fake);
+    // Three differently-corrupt records + one healthy MCP. Before the fix, any of
+    // the corrupt three threw a raw SyntaxError that aborted the whole listing.
+    seedCorruptRuntimeSkill(fake);
+    seedCorruptCustom(fake);
+    seedCorruptMcp(fake);
+    fake.seed({
+      name: 'mcp_server/acme/healthy',
+      recordType: 'MCP',
+      descriptors: { mcpServer: { data: JSON.stringify({ name: 'acme/healthy', version: '1.0.0', _meta: { [RUNTIME_META_KEY]: { transport: 'http', url: 'https://x' } } }) } },
+      recordVersion: '1.0.0',
+      status: 'APPROVED',
+    });
+    const records = await client.listRecords();
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({ kind: 'mcp_server', name: 'healthy' });
+  });
+
+  test('getRecord throws RegistryRecordMalformedError for a corrupt-runtime target record', async () => {
+    const fake = new FakeClient();
+    const client = makeClient(fake);
+    seedCorruptRuntimeSkill(fake, 'DRAFT');
+    await expect(client.getRecord('skill', 'acme', 'readme-helper', '1.0.0')).rejects.toBeInstanceOf(
+      RegistryRecordMalformedError,
+    );
+  });
+
   test('getRecord throws RegistryRecordMalformedError for a malformed target record', async () => {
     const fake = new FakeClient();
     const client = makeClient(fake);

--- a/cdk/test/handlers/shared/agent-registry-client.test.ts
+++ b/cdk/test/handlers/shared/agent-registry-client.test.ts
@@ -18,6 +18,7 @@
  */
 
 import {
+  ConflictException,
   CreateRegistryRecordCommand,
   GetRegistryRecordCommand,
   ListRegistryRecordsCommand,
@@ -676,5 +677,155 @@ describe('AgentRegistryClient', () => {
     const meta = (record.discovery as Record<string, unknown>)._meta as Record<string, unknown>;
     // ABCA runtime rides under its key AND the caller's own _meta key survives.
     expect(meta).toMatchObject({ [RUNTIME_META_KEY]: runtime, 'io.example.custom': { keep: true } });
+  });
+
+  // --- publisher preservation (the property this PR is named after) -----------
+
+  const seedHealthyMcp = (fake: FakeClient, meta: Record<string, unknown>, status = 'APPROVED'): string =>
+    fake.seed({
+      name: 'mcp_server/acme/pdf-tools',
+      recordType: 'MCP',
+      descriptors: {
+        mcpServer: {
+          data: JSON.stringify({
+            name: 'acme/pdf-tools',
+            version: '1.0.0',
+            _meta: { [RUNTIME_META_KEY]: { transport: 'http', url: 'https://x' }, ...meta },
+          }),
+        },
+      },
+      recordVersion: '1.0.0',
+      status,
+    });
+
+  test('resolve/getRecord preserve a healthy record publisher (read-path positive control)', async () => {
+    const fake = new FakeClient();
+    const client = makeClient(fake);
+    seedHealthyMcp(fake, { 'dev.abca.publisher': 'cognito-sub-999' });
+    const record = await client.getRecord('mcp_server', 'acme', 'pdf-tools', '1.0.0');
+    // If PUBLISHER_META_KEY/parse regresses, attribution silently drops from every
+    // healthy record — this pins it.
+    expect(record?.publisher).toBe('cognito-sub-999');
+  });
+
+  // A publisher that is *present but wrong-typed* must fail closed as MALFORMED:
+  // coercing it to `undefined` would leave the record APPROVED and loadable while
+  // attribution is silently erased — #791's vulnerability verbatim (#837 review).
+  test.each([
+    ['a number', 123],
+    ['an array', ['cognito-sub']],
+    ['an object', { sub: 'x' }],
+  ])('getRecord rejects a healthy record whose publisher is %s (MALFORMED, not silent drop)', async (_label, badPublisher) => {
+    const fake = new FakeClient();
+    const client = makeClient(fake);
+    seedHealthyMcp(fake, { 'dev.abca.publisher': badPublisher });
+    await expect(client.getRecord('mcp_server', 'acme', 'pdf-tools', '1.0.0')).rejects.toBeInstanceOf(
+      RegistryRecordMalformedError,
+    );
+  });
+
+  // --- wrong-shape descriptors (valid JSON, not an object) --------------------
+
+  // JSON.parse succeeds on these, so the pre-#837 boxing (catch SyntaxError only)
+  // walked them straight through and the next line dereferenced a non-object,
+  // escaping resolve as an opaque 500 across the whole namespace (#837 review).
+  test.each([
+    ['null', 'null'],
+    ['a number', '123'],
+    ['an array', '[1, 2]'],
+    ['a string', '"just a string"'],
+  ])('resolve fails closed (MALFORMED) when a CUSTOM body parses to %s', async (_label, data) => {
+    const fake = new FakeClient();
+    const client = makeClient(fake);
+    fake.seed({
+      name: 'cedar_policy_module/acme/permit',
+      recordType: 'CUSTOM',
+      descriptors: { custom: { data } },
+      recordVersion: '1.0.0',
+      status: 'APPROVED',
+    });
+    const parsed = parseRef('registry://cedar_policy_module/acme/permit@1.0.0');
+    if (!parsed.ok) throw new Error('fixture ref should parse');
+    await expect(client.resolve(parsed.ref)).rejects.toMatchObject({ reason: 'MALFORMED' });
+  });
+
+  test('resolve fails closed (MALFORMED) when an MCP body parses to a non-object', async () => {
+    const fake = new FakeClient();
+    const client = makeClient(fake);
+    fake.seed({
+      name: 'mcp_server/acme/pdf-tools',
+      recordType: 'MCP',
+      descriptors: { mcpServer: { data: '[1, 2]' } },
+      recordVersion: '1.0.0',
+      status: 'APPROVED',
+    });
+    const parsed = parseRef('registry://mcp_server/acme/pdf-tools@1.0.0');
+    if (!parsed.ok) throw new Error('fixture ref should parse');
+    await expect(client.resolve(parsed.ref)).rejects.toMatchObject({ reason: 'MALFORMED' });
+  });
+
+  test('resolve fails closed (MALFORMED) when SKILL.md frontmatter is a non-mapping (not a bare {})', async () => {
+    const fake = new FakeClient();
+    const client = makeClient(fake);
+    fake.seed({
+      name: 'skill/acme/readme-helper',
+      recordType: 'SKILL',
+      descriptors: {
+        agentSkillsDefinition: { additionalData: { skillMd: { data: '---\n- a\n- b\n---\n# body' } } },
+      },
+      recordVersion: '1.0.0',
+      status: 'APPROVED',
+    });
+    const parsed = parseRef('registry://skill/acme/readme-helper@1.0.0');
+    if (!parsed.ok) throw new Error('fixture ref should parse');
+    await expect(client.resolve(parsed.ref)).rejects.toMatchObject({ reason: 'MALFORMED' });
+  });
+
+  // --- 422 body must not echo raw descriptor bytes ----------------------------
+
+  test('resolve MALFORMED message carries the discriminator, never the raw descriptor bytes', async () => {
+    const fake = new FakeClient();
+    const client = makeClient(fake);
+    // An unterminated JSON body embedding a secret-looking token; Node's parser
+    // error quotes a window around the failure position that could include it.
+    fake.seed({
+      name: 'mcp_server/acme/pdf-tools',
+      recordType: 'MCP',
+      descriptors: { mcpServer: { data: '{"_meta": {"dev.abca.runtime": SUPERSECRETTOKEN' } },
+      recordVersion: '1.0.0',
+      status: 'APPROVED',
+    });
+    const parsed = parseRef('registry://mcp_server/acme/pdf-tools@1.0.0');
+    if (!parsed.ok) throw new Error('fixture ref should parse');
+    const err = await client.resolve(parsed.ref).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(RegistryResolutionError);
+    expect((err as RegistryResolutionError).message).toContain('MALFORMED_DESCRIPTOR');
+    expect((err as RegistryResolutionError).message).not.toContain('SUPERSECRETTOKEN');
+  });
+
+  // --- publish over a corrupt slot is a conflict (409), not an opaque 500 -----
+
+  test('publish over coordinates holding a malformed record throws ConflictException (not a bare 500)', async () => {
+    const fake = new FakeClient();
+    const client = makeClient(fake);
+    // A corrupt record already occupies mcp_server/acme/pdf-tools@1.0.0.
+    fake.seed({
+      name: 'mcp_server/acme/pdf-tools',
+      recordType: 'MCP',
+      descriptors: { mcpServer: { data: '{bad json' } },
+      recordVersion: '1.0.0',
+      status: 'APPROVED',
+    });
+    const err = await client.publish({
+      kind: 'mcp_server',
+      namespace: 'acme',
+      name: 'pdf-tools',
+      version: '1.0.0',
+      discovery: { name: 'acme/pdf-tools', description: 'd', version: '1.0.0' },
+      runtime: { transport: 'http' as const, url: 'https://x' },
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ConflictException);
+    // Never attempted to create over the occupied (corrupt) slot.
+    expect(fake.sent).toEqual([]);
   });
 });

--- a/cli/src/commands/registry.ts
+++ b/cli/src/commands/registry.ts
@@ -146,8 +146,9 @@ export function makeRegistryCommand(): Command {
         console.log(`${result.kind}/${result.namespace}/${result.name}`);
         console.log(`${'VERSION'.padEnd(VERSION_WIDTH)} ${'STATUS'.padEnd(NS_WIDTH)} CREATED`);
         for (const v of result.versions) {
+          const created = v.malformed ? 'MALFORMED (descriptor unparseable)' : v.created_at ?? '-';
           console.log(
-            `${v.version.padEnd(VERSION_WIDTH)} ${v.status.padEnd(NS_WIDTH)} ${v.created_at ?? '-'}`,
+            `${v.version.padEnd(VERSION_WIDTH)} ${v.status.padEnd(NS_WIDTH)} ${created}`,
           );
         }
       }),

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -66,6 +66,10 @@ export type RegistryVersionSummary = {
   readonly status: string;
   readonly created_at: string | null;
   readonly publisher: string | null;
+  /** True when the record's descriptor payload failed to parse — its publisher
+   *  and created_at are unrecoverable (erased), so they read `null`. Surfaced
+   *  rather than hidden so a corrupt version is visible to operators (#791). */
+  readonly malformed?: boolean;
 };
 
 /** `GET /registry/records/{kind}/{namespace}/{name}` response — one asset's

--- a/cli/src/types.ts
+++ b/cli/src/types.ts
@@ -66,9 +66,11 @@ export type RegistryVersionSummary = {
   readonly status: string;
   readonly created_at: string | null;
   readonly publisher: string | null;
-  /** True when the record's descriptor payload failed to parse — its publisher
-   *  and created_at are unrecoverable (erased), so they read `null`. Surfaced
-   *  rather than hidden so a corrupt version is visible to operators (#791). */
+  /** True when the record's descriptor payload failed to parse. `publisher` lives
+   *  in the erased payload so it is unrecoverable (reads `null`); `created_at` is
+   *  envelope data and is nulled only by the `show` marker's convention, not
+   *  because it is lost. Surfaced rather than hidden so a corrupt version is
+   *  visible to operators (#791). */
   readonly malformed?: boolean;
 };
 

--- a/docs/design/REGISTRY.md
+++ b/docs/design/REGISTRY.md
@@ -125,7 +125,7 @@ The registry API is a **separate API Gateway** from the main Task API (its own `
 
 - Parses the ref, gathers candidate versions, ranks by semver, applies the constraint + status rules (§8).
 - Response `200`: `{ kind, namespace, name, version, runtime, warnings[] }`.
-- Failure: `422 REGISTRY_RESOLUTION_FAILED` with `reason ∈ { NO_MATCHING_VERSION, REMOVED, INVALID_CONSTRAINT, INVALID_REGISTRY_REF }`.
+- Failure: `422 REGISTRY_RESOLUTION_FAILED` with `reason ∈ { NO_MATCHING_VERSION, REMOVED, INVALID_CONSTRAINT, INVALID_REGISTRY_REF, MALFORMED }`. `MALFORMED` means the winning record's descriptor is present but unparseable (e.g. SKILL.md frontmatter that fails to YAML-parse) — it is rejected rather than resolved with erased attribution (#791), and never downgraded to a lower valid version.
 
 ### 7.3 `GET /registry/records?kind=&namespace=` — list
 
@@ -158,7 +158,7 @@ The registry API is a **separate API Gateway** from the main Task API (its own `
 | `DEPRECATED` | yes | resolves + `warnings: ["DEPRECATED"]` |
 | `DRAFT`, `PENDING_APPROVAL`, `REJECTED`, `CREATING` | no | not a candidate; if the only match → `NO_MATCHING_VERSION` |
 
-**Fail-closed:** any unresolved ref fails task admission with `REGISTRY_RESOLUTION_FAILED`. A running task never re-resolves or substitutes.
+**Fail-closed:** any unresolved ref fails task admission with `REGISTRY_RESOLUTION_FAILED`. A running task never re-resolves or substitutes. A candidate whose descriptor is present but unparseable rejects the ref with `MALFORMED` — it is never silently skipped in favour of a lower valid version, so a corrupt payload cannot cause a stale downgrade (#791).
 
 ## 9. Access control (MVP)
 

--- a/docs/design/REGISTRY.md
+++ b/docs/design/REGISTRY.md
@@ -133,7 +133,7 @@ The registry API is a **separate API Gateway** from the main Task API (its own `
 
 ### 7.4 `GET /registry/records/{kind}/{namespace}/{name}` — show
 
-- Response `200`: `{ kind, namespace, name, versions: [{ version, status, created_at, publisher }] }` (highest-first).
+- Response `200`: `{ kind, namespace, name, versions: [{ version, status, created_at, publisher, malformed? }] }` (highest-first). A version whose descriptor payload failed to parse carries `malformed: true` with `publisher`/`created_at` `null` — surfaced (not hidden) so a corrupt version is visible to operators (#791).
 
 ## 8. Resolution semantics
 

--- a/docs/src/content/docs/architecture/Registry.md
+++ b/docs/src/content/docs/architecture/Registry.md
@@ -137,7 +137,7 @@ The registry API is a **separate API Gateway** from the main Task API (its own `
 
 ### 7.4 `GET /registry/records/{kind}/{namespace}/{name}` — show
 
-- Response `200`: `{ kind, namespace, name, versions: [{ version, status, created_at, publisher }] }` (highest-first).
+- Response `200`: `{ kind, namespace, name, versions: [{ version, status, created_at, publisher, malformed? }] }` (highest-first). A version whose descriptor payload failed to parse carries `malformed: true` with `publisher`/`created_at` `null` — surfaced (not hidden) so a corrupt version is visible to operators (#791).
 
 ## 8. Resolution semantics
 

--- a/docs/src/content/docs/architecture/Registry.md
+++ b/docs/src/content/docs/architecture/Registry.md
@@ -129,7 +129,7 @@ The registry API is a **separate API Gateway** from the main Task API (its own `
 
 - Parses the ref, gathers candidate versions, ranks by semver, applies the constraint + status rules (§8).
 - Response `200`: `{ kind, namespace, name, version, runtime, warnings[] }`.
-- Failure: `422 REGISTRY_RESOLUTION_FAILED` with `reason ∈ { NO_MATCHING_VERSION, REMOVED, INVALID_CONSTRAINT, INVALID_REGISTRY_REF }`.
+- Failure: `422 REGISTRY_RESOLUTION_FAILED` with `reason ∈ { NO_MATCHING_VERSION, REMOVED, INVALID_CONSTRAINT, INVALID_REGISTRY_REF, MALFORMED }`. `MALFORMED` means the winning record's descriptor is present but unparseable (e.g. SKILL.md frontmatter that fails to YAML-parse) — it is rejected rather than resolved with erased attribution (#791), and never downgraded to a lower valid version.
 
 ### 7.3 `GET /registry/records?kind=&namespace=` — list
 
@@ -162,7 +162,7 @@ The registry API is a **separate API Gateway** from the main Task API (its own `
 | `DEPRECATED` | yes | resolves + `warnings: ["DEPRECATED"]` |
 | `DRAFT`, `PENDING_APPROVAL`, `REJECTED`, `CREATING` | no | not a candidate; if the only match → `NO_MATCHING_VERSION` |
 
-**Fail-closed:** any unresolved ref fails task admission with `REGISTRY_RESOLUTION_FAILED`. A running task never re-resolves or substitutes.
+**Fail-closed:** any unresolved ref fails task admission with `REGISTRY_RESOLUTION_FAILED`. A running task never re-resolves or substitutes. A candidate whose descriptor is present but unparseable rejects the ref with `MALFORMED` — it is never silently skipped in favour of a lower valid version, so a corrupt payload cannot cause a stale downgrade (#791).
 
 ## 9. Access control (MVP)
 


### PR DESCRIPTION
## What & why

Closes #791 (P1, security — #756 Category 1).

A SKILL.md frontmatter block that fails to YAML-parse was **silently collapsed to `{}`** in both the TS adapter (`parseSkillFrontmatter`) and its Python mirror (`_extract_runtime`). Collapsing erases the **publisher** (attribution) and **runtime**, so a malformed record becomes indistinguishable from a legitimately empty one — letting attacker-influenced input drop an audit-critical trust field. It also disarms the duplicate-key frontmatter-injection defense (#664 / #246 B1/B2), which relies on the YAML error *surfacing* rather than being swallowed.

## Change

Both parse sites now raise a typed **`RegistryRecordMalformedError`** (new, mirrored across `cdk/.../registry/types.ts` and `agent/src/registry/client.py`) instead of returning `{}`. Both inline `nosemgrep: *-silent-success-masking` suppressions are removed.

Read-path behavior:

| Path | Behavior |
|------|----------|
| `resolve` | **Fail closed** — raises `RegistryResolutionError` with the new **`MALFORMED`** reason (distinct from `REMOVED`). A malformed *winning* version is rejected, **not** silently downgraded to a lower valid one. |
| `getRecord` | **Fail closed** — rethrows the parse failure for the targeted record. |
| `listRecords` (TS) | **Skip-with-warning** — one corrupt SKILL.md can't break enumerating a whole namespace. Browse tolerates; trust paths reject. |

TS carries malformed records as an envelope-identity marker (`RecordEntry`) so list/resolve/getRecord act on `kind/namespace/name/version/status` without trusting the erased payload. TS↔Python parity preserved (`MALFORMED` reason token added to both).

## Scope

Tightly scoped to the **two registry frontmatter sites**. The third suppression (`orchestration-store.ts parsePreScreenedAttachments`) is fail-safe screening (drops attachments, never passes unscreened content) and is **deferred to #792**.

## Testing

- `cdk`: 20/20 in `agent-registry-client.test.ts` (added 4: resolve→MALFORMED, reject-malformed-winner-no-downgrade, getRecord throws, listRecords skips). Full `mise //cdk:test` suite green.
- `agent`: 11/11 in `test_registry_agent_registry_client.py` (added malformed-raises-not-empty + malformed-winner-rejected).
- `mise //cdk:eslint`, agent `ruff check` + `ruff format --check` clean.
- Masking scan: both frontmatter suppressions removed with no new findings (the CI ratchet checks only new findings; this PR removes 2 and adds 0).

> `cdk:synth` fails **only** locally on `ec2:DescribeAvailabilityZones` (my Isengard role lacks the permission for AgentCore AZ resolution) — unrelated to this change; CI synths with proper credentials.