### PR TITLE
fix(deps): bump fast-uri past 4 HIGH advisories in both lockfiles

### DIFF
--- a/integrations/jira-forge-app/package-lock.json
+++ b/integrations/jira-forge-app/package-lock.json
@@ -385,9 +385,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/integrations/jira-forge-app/package.json
+++ b/integrations/jira-forge-app/package.json
@@ -11,7 +11,7 @@
   },
   "overrides": {
     "brace-expansion": "^5.0.9",
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.6",
     "undici": "^7.29.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@astrojs/markdown-remark": "7.2.0",
     "@astrojs/mdx": "6.0.3",
     "brace-expansion": "^5.0.9",
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.6",
     "fast-xml-parser": "^5.7.0",
     "ip-address": "^10.3.1",
     "js-yaml": "^4.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5131,10 +5131,10 @@ fast-string-width@^3.0.2:
   dependencies:
     fast-string-truncated-width "^3.0.2"
 
-fast-uri@^3.0.1, fast-uri@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
-  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
+fast-uri@^3.0.1, fast-uri@^3.1.6:
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.7.tgz#743157d957f3cbb4c65310e033dc2ad4ad7dc60a"
+  integrity sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==
 
 fast-wrap-ansi@^0.2.0:
   version "0.2.2"


### PR DESCRIPTION
Closes #848.

`security-pr` fails on `main`, and therefore on every branch merged with it. osv-scanner reports 8 findings across two lockfiles, all `fast-uri@3.1.5` — four distinct HIGH advisories, counted once per lockfile:

| Advisory | Issue |
|---|---|
| GHSA-5jgf-p345-68v8 | host confusion, skipped IDN |
| GHSA-jqff-g426-hqxp | host confusion, encoded scheme |
| GHSA-f65p-4m7j-42xc | SSRF, malformed IPv6 |
| GHSA-fph4-wmhf-6fwf | SSRF, repeated separators |

`fast-uri` is transitive (via `ajv`) and pins already existed in both places — both at `^3.1.5`, which resolves to exactly the vulnerable version. Bumped to `^3.1.6`; both lockfiles now resolve `3.1.7`.

Mirrored deliberately: `integrations/jira-forge-app` is a standalone npm project outside the yarn workspaces, so the root `resolutions` bump does not reach it and its `package-lock.json` has to be re-locked separately. That is the case `check:transitive-pin-sync` exists for (#712).

**Lockfile-only — no source change.** Four files: two pins, two lockfiles.

Verified locally:

- `mise run security:deps` → exit **0** (was 1)
- `mise run drift-prevention` → `check-transitive-pin-sync: OK — 4 shared pin(s) in sync between root resolutions and jira-forge-app`

Same shape as #637/#636. Filed separately rather than folded into #705, which this currently blocks but did not cause.
