### PR TITLE
fix(cdk): reclaim resource and byte headroom under both CFN ceilings (#852)

### DIFF
--- a/cdk/src/constructs/github-screenshot-integration.ts
+++ b/cdk/src/constructs/github-screenshot-integration.ts
@@ -414,7 +414,7 @@ export class GitHubScreenshotIntegration extends Construct {
     const webhookResource = githubResource.addResource('webhook');
     const webhookMethod = webhookResource.addMethod(
       'POST',
-      new apigw.LambdaIntegration(this.webhookFn),
+      new apigw.LambdaIntegration(this.webhookFn, { allowTestInvoke: false }),
       { authorizationType: apigw.AuthorizationType.NONE },
     );
 

--- a/cdk/src/constructs/jira-integration.ts
+++ b/cdk/src/constructs/jira-integration.ts
@@ -405,7 +405,7 @@ export class JiraIntegration extends Construct {
     const webhookResource = jira.addResource('webhook');
     const webhookMethod = webhookResource.addMethod(
       'POST',
-      new apigw.LambdaIntegration(webhookFn),
+      new apigw.LambdaIntegration(webhookFn, { allowTestInvoke: false }),
       noneAuthOptions,
     );
 
@@ -413,7 +413,7 @@ export class JiraIntegration extends Construct {
     const linkResource = jira.addResource('link');
     linkResource.addMethod(
       'POST',
-      new apigw.LambdaIntegration(linkFn),
+      new apigw.LambdaIntegration(linkFn, { allowTestInvoke: false }),
       cognitoAuthOptions,
     );
 

--- a/cdk/src/constructs/linear-integration.ts
+++ b/cdk/src/constructs/linear-integration.ts
@@ -411,7 +411,7 @@ export class LinearIntegration extends Construct {
     const webhookResource = linear.addResource('webhook');
     const webhookMethod = webhookResource.addMethod(
       'POST',
-      new apigw.LambdaIntegration(webhookFn),
+      new apigw.LambdaIntegration(webhookFn, { allowTestInvoke: false }),
       noneAuthOptions,
     );
 
@@ -419,7 +419,7 @@ export class LinearIntegration extends Construct {
     const linkResource = linear.addResource('link');
     linkResource.addMethod(
       'POST',
-      new apigw.LambdaIntegration(linkFn),
+      new apigw.LambdaIntegration(linkFn, { allowTestInvoke: false }),
       cognitoAuthOptions,
     );
 

--- a/cdk/src/constructs/registry-api.ts
+++ b/cdk/src/constructs/registry-api.ts
@@ -163,17 +163,17 @@ export class RegistryApi extends NestedStack {
     // --- Routes: /registry ---
     const registry = this.api.root.addResource('registry');
     const records = registry.addResource('records');
-    records.addMethod('POST', new apigw.LambdaIntegration(publishFn), authOptions);
-    records.addMethod('GET', new apigw.LambdaIntegration(listFn), authOptions);
+    records.addMethod('POST', new apigw.LambdaIntegration(publishFn, { allowTestInvoke: false }), authOptions);
+    records.addMethod('GET', new apigw.LambdaIntegration(listFn, { allowTestInvoke: false }), authOptions);
 
     const resolve = registry.addResource('resolve');
-    resolve.addMethod('GET', new apigw.LambdaIntegration(resolveFn), authOptions);
+    resolve.addMethod('GET', new apigw.LambdaIntegration(resolveFn, { allowTestInvoke: false }), authOptions);
 
     // show: /registry/records/{kind}/{namespace}/{name}
     const byKind = records.addResource('{kind}');
     const byNamespace = byKind.addResource('{namespace}');
     const byName = byNamespace.addResource('{name}');
-    byName.addMethod('GET', new apigw.LambdaIntegration(showFn), authOptions);
+    byName.addMethod('GET', new apigw.LambdaIntegration(showFn, { allowTestInvoke: false }), authOptions);
 
     this.apiUrl = this.api.url;
 

--- a/cdk/src/constructs/slack-integration.ts
+++ b/cdk/src/constructs/slack-integration.ts
@@ -393,7 +393,7 @@ export class SlackIntegration extends Construct {
     const oauthCallbackResource = oauthResource.addResource('callback');
     const oauthCallbackMethod = oauthCallbackResource.addMethod(
       'GET',
-      new apigw.LambdaIntegration(oauthCallbackFn),
+      new apigw.LambdaIntegration(oauthCallbackFn, { allowTestInvoke: false }),
       noneAuthOptions,
     );
 
@@ -401,7 +401,7 @@ export class SlackIntegration extends Construct {
     const eventsResource = slack.addResource('events');
     const eventsMethod = eventsResource.addMethod(
       'POST',
-      new apigw.LambdaIntegration(slackEventsAlias),
+      new apigw.LambdaIntegration(slackEventsAlias, { allowTestInvoke: false }),
       noneAuthOptions,
     );
 
@@ -409,7 +409,7 @@ export class SlackIntegration extends Construct {
     const commandsResource = slack.addResource('commands');
     const commandsMethod = commandsResource.addMethod(
       'POST',
-      new apigw.LambdaIntegration(slackCommandsFn),
+      new apigw.LambdaIntegration(slackCommandsFn, { allowTestInvoke: false }),
       noneAuthOptions,
     );
 
@@ -417,7 +417,7 @@ export class SlackIntegration extends Construct {
     const interactionsResource = slack.addResource('interactions');
     const interactionsMethod = interactionsResource.addMethod(
       'POST',
-      new apigw.LambdaIntegration(slackInteractionsFn),
+      new apigw.LambdaIntegration(slackInteractionsFn, { allowTestInvoke: false }),
       noneAuthOptions,
     );
 
@@ -425,7 +425,7 @@ export class SlackIntegration extends Construct {
     const linkResource = slack.addResource('link');
     linkResource.addMethod(
       'POST',
-      new apigw.LambdaIntegration(slackLinkFn),
+      new apigw.LambdaIntegration(slackLinkFn, { allowTestInvoke: false }),
       cognitoAuthOptions,
     );
 

--- a/cdk/src/constructs/task-api.ts
+++ b/cdk/src/constructs/task-api.ts
@@ -844,15 +844,14 @@ export class TaskApi extends Construct {
     const allFunctions: lambda.NodejsFunction[] = [createTaskFn, getTaskFn, listTasksFn, cancelTaskFn, getTaskEventsFn, getTaskReplayFn];
     if (confirmUploadsFn) allFunctions.push(confirmUploadsFn);
 
-    // Every `LambdaIntegration` below passes `allowTestInvoke: false`. The default
-    // (`true`) makes CDK emit a *second* `AWS::Lambda::Permission` per method, scoped
-    // to `method.testMethodArn`, so that the API Gateway console's "TEST" button works.
-    // Across the app that is 30 of the stack's 500-resource CloudFormation budget —
-    // and 30 extra `lambda:InvokeFunction` grants — spent on a console affordance
-    // nothing in this solution invokes. Real traffic is unaffected: with
-    // `scopePermissionToMethod` left at its default `true`, each route keeps its own
-    // narrowly-scoped `SourceArn`. Keep new routes consistent; `task-api.test.ts`
-    // asserts no `test-invoke-stage` permission is ever emitted. Refs #852.
+    // Every `LambdaIntegration` below passes `allowTestInvoke: false`, dropping the
+    // second `AWS::Lambda::Permission` per method that CDK emits by default for the
+    // API Gateway console's "TEST" button, which nothing here invokes. Real traffic is
+    // unaffected: `scopePermissionToMethod` stays at its default `true`, so each route
+    // keeps its own narrowly-scoped `SourceArn`. Keep new routes consistent;
+    // `test/stacks/agent.test.ts` asserts no `test-invoke-stage` permission is ever
+    // emitted.
+
     // --- API resource tree: /tasks ---
     const tasks = this.api.root.addResource('tasks');
     tasks.addMethod('POST', new apigw.LambdaIntegration(createTaskFn, { allowTestInvoke: false }), cognitoAuthOptions);

--- a/cdk/src/constructs/task-api.ts
+++ b/cdk/src/constructs/task-api.ts
@@ -844,27 +844,36 @@ export class TaskApi extends Construct {
     const allFunctions: lambda.NodejsFunction[] = [createTaskFn, getTaskFn, listTasksFn, cancelTaskFn, getTaskEventsFn, getTaskReplayFn];
     if (confirmUploadsFn) allFunctions.push(confirmUploadsFn);
 
+    // Every `LambdaIntegration` below passes `allowTestInvoke: false`. The default
+    // (`true`) makes CDK emit a *second* `AWS::Lambda::Permission` per method, scoped
+    // to `method.testMethodArn`, so that the API Gateway console's "TEST" button works.
+    // Across the app that is 30 of the stack's 500-resource CloudFormation budget —
+    // and 30 extra `lambda:InvokeFunction` grants — spent on a console affordance
+    // nothing in this solution invokes. Real traffic is unaffected: with
+    // `scopePermissionToMethod` left at its default `true`, each route keeps its own
+    // narrowly-scoped `SourceArn`. Keep new routes consistent; `task-api.test.ts`
+    // asserts no `test-invoke-stage` permission is ever emitted. Refs #852.
     // --- API resource tree: /tasks ---
     const tasks = this.api.root.addResource('tasks');
-    tasks.addMethod('POST', new apigw.LambdaIntegration(createTaskFn), cognitoAuthOptions);
-    tasks.addMethod('GET', new apigw.LambdaIntegration(listTasksFn), cognitoAuthOptions);
+    tasks.addMethod('POST', new apigw.LambdaIntegration(createTaskFn, { allowTestInvoke: false }), cognitoAuthOptions);
+    tasks.addMethod('GET', new apigw.LambdaIntegration(listTasksFn, { allowTestInvoke: false }), cognitoAuthOptions);
 
     const taskById = tasks.addResource('{task_id}');
-    taskById.addMethod('GET', new apigw.LambdaIntegration(getTaskFn), cognitoAuthOptions);
-    taskById.addMethod('DELETE', new apigw.LambdaIntegration(cancelTaskFn), cognitoAuthOptions);
+    taskById.addMethod('GET', new apigw.LambdaIntegration(getTaskFn, { allowTestInvoke: false }), cognitoAuthOptions);
+    taskById.addMethod('DELETE', new apigw.LambdaIntegration(cancelTaskFn, { allowTestInvoke: false }), cognitoAuthOptions);
 
     const events = taskById.addResource('events');
-    events.addMethod('GET', new apigw.LambdaIntegration(getTaskEventsFn), cognitoAuthOptions);
+    events.addMethod('GET', new apigw.LambdaIntegration(getTaskEventsFn, { allowTestInvoke: false }), cognitoAuthOptions);
 
     // Operator replay bundle: GET /tasks/{task_id}/replay. Same Cognito
     // owner-scoped auth as GET /tasks/{task_id} (cognitoAuthOptions).
     const replay = taskById.addResource('replay');
-    replay.addMethod('GET', new apigw.LambdaIntegration(getTaskReplayFn), cognitoAuthOptions);
+    replay.addMethod('GET', new apigw.LambdaIntegration(getTaskReplayFn, { allowTestInvoke: false }), cognitoAuthOptions);
 
     // --- Confirm-uploads endpoint: POST /tasks/{task_id}/confirm-uploads ---
     if (confirmUploadsFn) {
       const confirmUploads = taskById.addResource('confirm-uploads');
-      confirmUploads.addMethod('POST', new apigw.LambdaIntegration(confirmUploadsFn), cognitoAuthOptions);
+      confirmUploads.addMethod('POST', new apigw.LambdaIntegration(confirmUploadsFn, { allowTestInvoke: false }), cognitoAuthOptions);
     }
 
     // --- Trace URL endpoint (design §10.1): GET /tasks/{task_id}/trace ---
@@ -913,7 +922,7 @@ export class TaskApi extends Construct {
       }));
 
       const trace = taskById.addResource('trace');
-      trace.addMethod('GET', new apigw.LambdaIntegration(getTraceUrlFn), cognitoAuthOptions);
+      trace.addMethod('GET', new apigw.LambdaIntegration(getTraceUrlFn, { allowTestInvoke: false }), cognitoAuthOptions);
 
       allFunctions.push(getTraceUrlFn);
     }
@@ -957,7 +966,7 @@ export class TaskApi extends Construct {
       }
 
       const nudge = taskById.addResource('nudge');
-      nudge.addMethod('POST', new apigw.LambdaIntegration(nudgeTaskFn), cognitoAuthOptions);
+      nudge.addMethod('POST', new apigw.LambdaIntegration(nudgeTaskFn, { allowTestInvoke: false }), cognitoAuthOptions);
 
       allFunctions.push(nudgeTaskFn);
     }
@@ -1040,19 +1049,19 @@ export class TaskApi extends Construct {
       const approveTask = taskById.addResource('approve');
       approveTask.addMethod(
         'POST',
-        new apigw.LambdaIntegration(approveTaskFn),
+        new apigw.LambdaIntegration(approveTaskFn, { allowTestInvoke: false }),
         cognitoAuthOptions,
       );
       const denyTask = taskById.addResource('deny');
       denyTask.addMethod(
         'POST',
-        new apigw.LambdaIntegration(denyTaskFn),
+        new apigw.LambdaIntegration(denyTaskFn, { allowTestInvoke: false }),
         cognitoAuthOptions,
       );
       const pending = this.api.root.addResource('pending');
       pending.addMethod(
         'GET',
-        new apigw.LambdaIntegration(getPendingFn),
+        new apigw.LambdaIntegration(getPendingFn, { allowTestInvoke: false }),
         cognitoAuthOptions,
       );
 
@@ -1098,7 +1107,7 @@ export class TaskApi extends Construct {
         const policies = repoById.addResource('policies');
         policies.addMethod(
           'GET',
-          new apigw.LambdaIntegration(getPoliciesFn),
+          new apigw.LambdaIntegration(getPoliciesFn, { allowTestInvoke: false }),
           cognitoAuthOptions,
         );
         allFunctions.push(getPoliciesFn);
@@ -1191,11 +1200,11 @@ export class TaskApi extends Construct {
       props.apiKeyTable.grantReadWriteData(deleteApiKeyFn);
 
       const apiKeys = this.api.root.addResource('api-keys');
-      apiKeys.addMethod('POST', new apigw.LambdaIntegration(createApiKeyFn), cognitoAuthOptions);
-      apiKeys.addMethod('GET', new apigw.LambdaIntegration(listApiKeysFn), cognitoAuthOptions);
+      apiKeys.addMethod('POST', new apigw.LambdaIntegration(createApiKeyFn, { allowTestInvoke: false }), cognitoAuthOptions);
+      apiKeys.addMethod('GET', new apigw.LambdaIntegration(listApiKeysFn, { allowTestInvoke: false }), cognitoAuthOptions);
 
       const apiKeyById = apiKeys.addResource('{key_id}');
-      apiKeyById.addMethod('DELETE', new apigw.LambdaIntegration(deleteApiKeyFn), cognitoAuthOptions);
+      apiKeyById.addMethod('DELETE', new apigw.LambdaIntegration(deleteApiKeyFn, { allowTestInvoke: false }), cognitoAuthOptions);
 
       allFunctions.push(apiKeyAuthorizerFn, createApiKeyFn, listApiKeysFn, deleteApiKeyFn);
     }
@@ -1348,11 +1357,11 @@ export class TaskApi extends Construct {
       // Management routes use the unified authorizer when an API key table is
       // wired (JWT or `webhooks:manage` key), else fall back to Cognito-only.
       const webhooks = this.api.root.addResource('webhooks');
-      const createWebhookMethod = webhooks.addMethod('POST', new apigw.LambdaIntegration(createWebhookFn), webhookMgmtAuthOptions);
-      const listWebhooksMethod = webhooks.addMethod('GET', new apigw.LambdaIntegration(listWebhooksFn), webhookMgmtAuthOptions);
+      const createWebhookMethod = webhooks.addMethod('POST', new apigw.LambdaIntegration(createWebhookFn, { allowTestInvoke: false }), webhookMgmtAuthOptions);
+      const listWebhooksMethod = webhooks.addMethod('GET', new apigw.LambdaIntegration(listWebhooksFn, { allowTestInvoke: false }), webhookMgmtAuthOptions);
 
       const webhookById = webhooks.addResource('{webhook_id}');
-      const deleteWebhookMethod = webhookById.addMethod('DELETE', new apigw.LambdaIntegration(deleteWebhookFn), webhookMgmtAuthOptions);
+      const deleteWebhookMethod = webhookById.addMethod('DELETE', new apigw.LambdaIntegration(deleteWebhookFn, { allowTestInvoke: false }), webhookMgmtAuthOptions);
 
       // When the unified authorizer is in use these methods are CUSTOM, not
       // Cognito — suppress COG4 (the authorizer still enforces a Cognito JWT
@@ -1367,7 +1376,7 @@ export class TaskApi extends Construct {
       }
 
       const webhookTasks = webhooks.addResource('tasks');
-      const webhookTasksMethod = webhookTasks.addMethod('POST', new apigw.LambdaIntegration(webhookCreateTaskFn), webhookAuthOptions);
+      const webhookTasksMethod = webhookTasks.addMethod('POST', new apigw.LambdaIntegration(webhookCreateTaskFn, { allowTestInvoke: false }), webhookAuthOptions);
 
       NagSuppressions.addResourceSuppressions(webhookTasksMethod, [
         {

--- a/cdk/src/main.ts
+++ b/cdk/src/main.ts
@@ -92,12 +92,7 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<App> {
       env,
       agentCoreAvailabilityZones: azResolution.zones,
       description: 'ABCA Development Stack (uksb-wt64nei4u6)',
-      // Emit compact JSON. ~31% of this template is pretty-print indentation, and
-      // CloudFormation's 1 MB template-body ceiling counts those bytes. Unlike the
-      // 500-resource ceiling — which CDK enforces by throwing `TooManyResourcesInStack`
-      // — the byte ceiling only raises an `@aws-cdk/core:Stack.templateSize` warning,
-      // so it fails *open*: a template can grow past it and still synthesize. CDK's own
-      // warning text names this prop as the remedy. Refs #852.
+      // Emit compact JSON for a CloudFormation 1 MB template-body ceiling.
       suppressTemplateIndentation: true,
     },
   );

--- a/cdk/src/main.ts
+++ b/cdk/src/main.ts
@@ -92,6 +92,13 @@ export async function buildApp(options: BuildAppOptions = {}): Promise<App> {
       env,
       agentCoreAvailabilityZones: azResolution.zones,
       description: 'ABCA Development Stack (uksb-wt64nei4u6)',
+      // Emit compact JSON. ~31% of this template is pretty-print indentation, and
+      // CloudFormation's 1 MB template-body ceiling counts those bytes. Unlike the
+      // 500-resource ceiling — which CDK enforces by throwing `TooManyResourcesInStack`
+      // — the byte ceiling only raises an `@aws-cdk/core:Stack.templateSize` warning,
+      // so it fails *open*: a template can grow past it and still synthesize. CDK's own
+      // warning text names this prop as the remedy. Refs #852.
+      suppressTemplateIndentation: true,
     },
   );
 

--- a/cdk/test/main.test.ts
+++ b/cdk/test/main.test.ts
@@ -17,6 +17,7 @@
  *  SOFTWARE.
  */
 
+import * as fs from 'fs';
 import { App, Stack } from 'aws-cdk-lib';
 import { Annotations, Match, Template } from 'aws-cdk-lib/assertions';
 import {
@@ -151,5 +152,43 @@ describe('buildApp — AgentCore AZ wiring', () => {
         appProps: { context: { [AGENTCORE_AZS_CONTEXT_KEY]: 'us-east-1b' } },
       }),
     ).rejects.toThrow(/must be a JSON array of availability-zone names/);
+  });
+});
+
+describe('buildApp — CloudFormation template-body budget (#852)', () => {
+  // CloudFormation caps a template body at 1 MB; CDK checks against
+  // `TEMPLATE_BODY_MAXIMUM_SIZE = 1e6` and, unlike the 500-resource ceiling, only
+  // raises an `@aws-cdk/core:Stack.templateSize` *warning* — so this ceiling fails
+  // **open**. A template can grow past it, synthesize cleanly, and fail at deploy.
+  // These assertions read the emitted artifact rather than `Template.fromStack`,
+  // because indentation is the thing under test and `Template` has already parsed
+  // it away.
+  const CDK_TEMPLATE_BODY_MAXIMUM_SIZE = 1_000_000;
+  // CDK starts warning at 80% of the maximum. Budgeting to the same number means a
+  // regression trips this assertion at exactly the point CDK would start warning,
+  // instead of silently riding the warning band up to the hard limit.
+  const TEMPLATE_BODY_BUDGET = CDK_TEMPLATE_BODY_MAXIMUM_SIZE * 0.8;
+
+  let templateText: string;
+
+  beforeAll(async () => {
+    const built = await app();
+    templateText = fs.readFileSync(
+      built.synth().getStackByName(STACK_NAME).templateFullPath,
+      'utf8',
+    );
+  });
+
+  it('emits the template without pretty-print indentation', () => {
+    // `suppressTemplateIndentation: true` in main.ts makes CDK pass `undefined` as
+    // JSON.stringify's `space` argument, collapsing the document to a single line.
+    // Roughly 31% of this template was indentation bytes, all of which counted
+    // against the 1 MB ceiling. Assert the shape, not the saving, so the test does
+    // not need re-baselining every time a resource is added.
+    expect(templateText).not.toContain('\n  ');
+  });
+
+  it('stays inside the template-body budget', () => {
+    expect(Buffer.byteLength(templateText, 'utf8')).toBeLessThan(TEMPLATE_BODY_BUDGET);
   });
 });

--- a/cdk/test/main.test.ts
+++ b/cdk/test/main.test.ts
@@ -155,19 +155,19 @@ describe('buildApp — AgentCore AZ wiring', () => {
   });
 });
 
-describe('buildApp — CloudFormation template-body budget (#852)', () => {
+describe('buildApp — CloudFormation template-body budget within 80% 1Mb budget', () => {
   // CloudFormation caps a template body at 1 MB; CDK checks against
-  // `TEMPLATE_BODY_MAXIMUM_SIZE = 1e6` and, unlike the 500-resource ceiling, only
+  // `TEMPLATE_BODY_MAXIMUM_SIZE = 1e6` and only
   // raises an `@aws-cdk/core:Stack.templateSize` *warning* — so this ceiling fails
   // **open**. A template can grow past it, synthesize cleanly, and fail at deploy.
   // These assertions read the emitted artifact rather than `Template.fromStack`,
   // because indentation is the thing under test and `Template` has already parsed
   // it away.
   const CDK_TEMPLATE_BODY_MAXIMUM_SIZE = 1_000_000;
-  // CDK starts warning at 80% of the maximum. Budgeting to the same number means a
-  // regression trips this assertion at exactly the point CDK would start warning,
+  // Budget to the point CDK starts warning, so a regression trips a readable assertion
   // instead of silently riding the warning band up to the hard limit.
-  const TEMPLATE_BODY_BUDGET = CDK_TEMPLATE_BODY_MAXIMUM_SIZE * 0.8;
+  const WARNING_THRESHOLD = 0.8;
+  const TEMPLATE_BODY_BUDGET = CDK_TEMPLATE_BODY_MAXIMUM_SIZE * WARNING_THRESHOLD;
 
   let templateText: string;
 
@@ -180,10 +180,7 @@ describe('buildApp — CloudFormation template-body budget (#852)', () => {
   });
 
   it('emits the template without pretty-print indentation', () => {
-    // `suppressTemplateIndentation: true` in main.ts makes CDK pass `undefined` as
-    // JSON.stringify's `space` argument, collapsing the document to a single line.
-    // Roughly 31% of this template was indentation bytes, all of which counted
-    // against the 1 MB ceiling. Assert the shape, not the saving, so the test does
+    // Assert the shape, not the saving, so the test does
     // not need re-baselining every time a resource is added.
     expect(templateText).not.toContain('\n  ');
   });

--- a/cdk/test/stacks/agent.test.ts
+++ b/cdk/test/stacks/agent.test.ts
@@ -1576,6 +1576,57 @@ describe('AgentStack tool-gateway gate (ADR-019 P1)', () => {
   });
 });
 
+describe('AgentStack CloudFormation resource budget (#852)', () => {
+  // The 500-resource limit is a hard, non-adjustable CloudFormation template quota,
+  // and CDK enforces it by *throwing* `TooManyResourcesInStack` during synth. The
+  // widest cell of the deploy gate is `compute_type=lambda-microvm` with the ADR-019
+  // tool gateway on: the MicroVM substrate is additive over AgentCore, and the gateway
+  // adds a flat +7 on every substrate. Before #852 that pairing synthesized 504
+  // resources — `main` could not produce a template for it at all — yet CI stayed
+  // green because no test had ever constructed the two flags *together*. This block
+  // exists so that the widest cell, not the default one, is what guards the ceiling.
+  //
+  // Budget is deliberately below 500 so this fails as a readable assertion with a
+  // named remedy, ten resources before synth starts throwing.
+  const WIDEST_CONFIG_RESOURCE_BUDGET = 490;
+
+  let template: Template;
+  let resourceCount: number;
+
+  beforeAll(() => {
+    const app = new App({
+      context: { compute_type: 'lambda-microvm', enableToolGateway: true },
+    });
+    const stack = new AgentStack(app, 'WidestConfigStack', {
+      env: { account: '123456789012', region: 'us-east-1' },
+    });
+    // Throws `TooManyResourcesInStack` if this cell is over the hard ceiling, so
+    // reaching the assertions below is itself part of the guard.
+    template = Template.fromStack(stack);
+    resourceCount = Object.keys(template.toJSON().Resources ?? {}).length;
+  });
+
+  test('the widest deploy-gate cell stays inside the resource budget', () => {
+    // `Template.fromStack` counts one fewer than `cdk synth`, which also emits
+    // `AWS::CDK::Metadata`. Budget the synthesized number, so add that resource back.
+    expect(resourceCount + 1).toBeLessThanOrEqual(WIDEST_CONFIG_RESOURCE_BUDGET);
+  });
+
+  test('no Lambda permission is emitted for the API Gateway console test-invoke stage', () => {
+    // Every `LambdaIntegration` in this app passes `allowTestInvoke: false`. Left at
+    // its default `true`, CDK emits a second `AWS::Lambda::Permission` per method
+    // scoped to `method.testMethodArn` — 30 resources of the 500-resource budget, plus
+    // 30 extra `lambda:InvokeFunction` grants, so the API Gateway console's "TEST"
+    // button works. Nothing in this solution invokes it. Naming the offending logical
+    // IDs makes a regressed call site point straight at its own construct.
+    const offenders = Object.entries(template.findResources('AWS::Lambda::Permission'))
+      .filter(([, resource]) => JSON.stringify(resource).includes('test-invoke-stage'))
+      .map(([logicalId]) => logicalId);
+
+    expect(offenders).toEqual([]);
+  });
+});
+
 describe('AgentStack Agent Registry gate', () => {
   test.each([undefined, true, 'true'])(
     'enableAgentRegistry=%p includes the registry by default or explicit enablement',

--- a/cdk/test/stacks/agent.test.ts
+++ b/cdk/test/stacks/agent.test.ts
@@ -1576,55 +1576,64 @@ describe('AgentStack tool-gateway gate (ADR-019 P1)', () => {
   });
 });
 
-describe('AgentStack CloudFormation resource budget (#852)', () => {
+describe('AgentStack CloudFormation resource budget 500 with cushion', () => {
   // The 500-resource limit is a hard, non-adjustable CloudFormation template quota,
-  // and CDK enforces it by *throwing* `TooManyResourcesInStack` during synth. The
-  // widest cell of the deploy gate is `compute_type=lambda-microvm` with the ADR-019
-  // tool gateway on: the MicroVM substrate is additive over AgentCore, and the gateway
-  // adds a flat +7 on every substrate. Before #852 that pairing synthesized 504
-  // resources — `main` could not produce a template for it at all — yet CI stayed
-  // green because no test had ever constructed the two flags *together*. This block
-  // exists so that the widest cell, not the default one, is what guards the ceiling.
-  //
-  // Budget is deliberately below 500 so this fails as a readable assertion with a
-  // named remedy, ten resources before synth starts throwing.
-  const WIDEST_CONFIG_RESOURCE_BUDGET = 490;
+  // and CDK enforces it by *throwing* `TooManyResourcesInStack` during synth.
+  // Every deploy-gate cell is covered, not only the widest, so a regression confined
+  // to one substrate cannot hide behind the others. The gap this closes: no test had
+  // ever constructed `compute_type` and `enableToolGateway` *together*, so the widest
+  // cell could exceed the quota — unable to synthesize at all — with CI still green.
+  // Budget is deliberately below the quota so this fails as a readable assertion with a
+  // named remedy before synth starts throwing.
+  const MAX_RESOURCE_BUDGET = 500;
+  const CUSHION = 10;
+  const RESOURCE_BUDGET = MAX_RESOURCE_BUDGET - CUSHION;
 
-  let template: Template;
-  let resourceCount: number;
+  // `Template.fromStack` counts one fewer than `cdk synth`, which also emits
+  // `AWS::CDK::Metadata`. Budget the synthesized number, so add that resource back.
+  const SYNTH_ONLY_RESOURCES = 1;
 
-  beforeAll(() => {
-    const app = new App({
-      context: { compute_type: 'lambda-microvm', enableToolGateway: true },
-    });
-    const stack = new AgentStack(app, 'WidestConfigStack', {
-      env: { account: '123456789012', region: 'us-east-1' },
-    });
-    // Throws `TooManyResourcesInStack` if this cell is over the hard ceiling, so
-    // reaching the assertions below is itself part of the guard.
-    template = Template.fromStack(stack);
-    resourceCount = Object.keys(template.toJSON().Resources ?? {}).length;
-  });
+  const COMPUTE_TYPES = ['agentcore', 'ecs', 'lambda-microvm'];
+  const CELLS = COMPUTE_TYPES.flatMap(computeType =>
+    [false, true].map(enableToolGateway => ({ computeType, enableToolGateway })),
+  );
 
-  test('the widest deploy-gate cell stays inside the resource budget', () => {
-    // `Template.fromStack` counts one fewer than `cdk synth`, which also emits
-    // `AWS::CDK::Metadata`. Budget the synthesized number, so add that resource back.
-    expect(resourceCount + 1).toBeLessThanOrEqual(WIDEST_CONFIG_RESOURCE_BUDGET);
-  });
+  describe.each(CELLS)(
+    'compute_type=$computeType enableToolGateway=$enableToolGateway',
+    ({ computeType, enableToolGateway }) => {
+      let template: Template;
 
-  test('no Lambda permission is emitted for the API Gateway console test-invoke stage', () => {
-    // Every `LambdaIntegration` in this app passes `allowTestInvoke: false`. Left at
-    // its default `true`, CDK emits a second `AWS::Lambda::Permission` per method
-    // scoped to `method.testMethodArn` — 30 resources of the 500-resource budget, plus
-    // 30 extra `lambda:InvokeFunction` grants, so the API Gateway console's "TEST"
-    // button works. Nothing in this solution invokes it. Naming the offending logical
-    // IDs makes a regressed call site point straight at its own construct.
-    const offenders = Object.entries(template.findResources('AWS::Lambda::Permission'))
-      .filter(([, resource]) => JSON.stringify(resource).includes('test-invoke-stage'))
-      .map(([logicalId]) => logicalId);
+      beforeAll(() => {
+        const app = new App({ context: { compute_type: computeType, enableToolGateway } });
+        const stack = new AgentStack(app, 'BudgetStack', {
+          env: { account: '123456789012', region: 'us-east-1' },
+        });
+        // Throws `TooManyResourcesInStack` if this cell is over the hard quota, so
+        // reaching the assertions below is itself part of the guard.
+        template = Template.fromStack(stack);
+      });
 
-    expect(offenders).toEqual([]);
-  });
+      test('stays inside the resource budget', () => {
+        const resourceCount = Object.keys(template.toJSON().Resources ?? {}).length;
+        expect(resourceCount + SYNTH_ONLY_RESOURCES).toBeLessThanOrEqual(RESOURCE_BUDGET);
+      });
+
+      test('emits no Lambda permission for the API Gateway console test-invoke stage', () => {
+        // Every `LambdaIntegration` in this app passes `allowTestInvoke: false`. Left at
+        // its default `true`, CDK emits a second `AWS::Lambda::Permission` per method
+        // scoped to `method.testMethodArn` — removing the API Gateway console's "TEST"
+        // button, which nothing in this solution invokes, and its extra
+        // `lambda:InvokeFunction` grant.
+        // Naming the offending logical IDs makes a regressed call site point straight
+        // at its own construct.
+        const offenders = Object.entries(template.findResources('AWS::Lambda::Permission'))
+          .filter(([, resource]) => JSON.stringify(resource).includes('test-invoke-stage'))
+          .map(([logicalId]) => logicalId);
+
+        expect(offenders).toEqual([]);
+      });
+    },
+  );
 });
 
 describe('AgentStack Agent Registry gate', () => {


### PR DESCRIPTION
Two configuration changes that pull the stack back inside CloudFormation's two template ceilings, with no architectural change and no API-contract change.

The widest cell of the deploy gate — `compute_type=lambda-microvm` with the ADR-019 tool gateway on — **could not synthesize on `main` at all**: 504 resources against the hard 500-resource template quota, which CDK enforces by throwing `TooManyResourcesInStack`. The same stack was also at ~100% of the 1 MB template-body ceiling, which CDK only *warns* about — so that limit was being ridden over silently.

#### Area

- [x] `cdk` — infrastructure, handlers, constructs
- [ ] `agent` — Python runtime / Docker image
- [ ] `cli` — `bgagent` client
- [ ] `docs` — guides or design sources (`docs/guides/`, `docs/design/`)
- [ ] `tooling` — root `mise.toml`, scripts, CI workflows

#### Related

Refs #852 — Tier 0 of the strategies catalogued there. This is deliberately **not** a fix for #852; it buys headroom so the structural work (stack split) can be done under review rather than under a broken build. Adjacent: #851, #735.

#### Changes

**1. `allowTestInvoke: false` on all 34 `LambdaIntegration` call sites** — −30 resources app-wide.

The default (`true`) makes CDK emit a *second* `AWS::Lambda::Permission` per method, scoped to `method.testMethodArn`, so the API Gateway console's "TEST" button works. Nothing in this solution invokes it. Each one is also an extra `lambda:InvokeFunction` grant, so this narrows the IAM surface as well as the resource count.

Real traffic is unaffected. `scopePermissionToMethod` stays at its default `true`, so every route keeps its own narrowly-scoped `SourceArn`. That distinction matters: the two options are **alternatives, not additive** — setting `scopePermissionToMethod: false` saves the same 30 resources but widens every `SourceArn` to `.../{TaskApi}/*/*/*`, which is why #852 rejects it.

| File | Call sites |
|---|---:|
| `cdk/src/constructs/task-api.ts` | 20 |
| `cdk/src/constructs/slack-integration.ts` | 5 |
| `cdk/src/constructs/registry-api.ts` | 4 |
| `cdk/src/constructs/linear-integration.ts` | 2 |
| `cdk/src/constructs/jira-integration.ts` | 2 |
| `cdk/src/constructs/github-screenshot-integration.ts` | 1 |

**2. `suppressTemplateIndentation: true` on `AgentStack`** (`cdk/src/main.ts`) — ~31% fewer bytes, 0 resources.

Roughly a third of the emitted template was pretty-print indentation, every byte of which counted against the 1 MB ceiling. CDK's own `@aws-cdk/core:Stack.templateSize` warning names this prop as the remedy.

Set as a `StackProps` value rather than via the `@aws-cdk/core:suppressTemplateIndentation` context key. Both work — `Stack` resolves `props.suppressTemplateIndentation ?? node.tryGetContext(...) ?? false` — but the prop keeps the blast radius to the one stack that is actually near the ceiling. **Known limitation:** the two nested stacks (`AgentRegistryStack`, `RegistryApi`) therefore stay pretty-printed. They are small, and only the context key would reach them.

#### Measured

Resource counts and bytes are from `cdk synth` (which emits one `AWS::CDK::Metadata` that `Template.fromStack` does not), each run into its own `--output` directory.

| Deploy-gate cell | `main` | this PR |
|---|---|---|
| default (`agentcore`) | 480 res · 961,200 B (96.1%) | **450 res · 640,377 B (64.0%)** |
| `compute_type=ecs` | 492 res · 996,129 B (99.6%) | **462 res · 662,670 B (66.3%)** |
| `lambda-microvm` + `enableToolGateway` — **widest** | **504 res — `TooManyResourcesInStack`, no template emitted** | **474 res · 687,955 B (68.8%)** |

Every cell moves −30 resources exactly, and the widest one goes from "cannot synthesize" to 26 resources of headroom under the ceiling. The `enableToolGateway`-only cell is still measuring and will be added; it is a flat +7 on whichever substrate it is combined with.

CDK checks bytes against `TEMPLATE_BODY_MAXIMUM_SIZE = 1e6`, not 1,048,576 — percentages above use `1e6`.

#### Tests

Both gaps that let the broken cell stay green in CI are closed:

- `cdk/test/stacks/agent.test.ts` — new `AgentStack CloudFormation resource budget (#852)` block. It is the first test to construct `compute_type=lambda-microvm` **and** `enableToolGateway=true` together, which is precisely why the 504-resource cell was never red. `Template.fromStack` throws if the cell is over the hard ceiling, so reaching the assertions is itself part of the guard; the budget is set to 490 so it fails as a readable assertion ten resources before synth starts throwing.
- Same block — asserts no `AWS::Lambda::Permission` referencing `test-invoke-stage` is emitted anywhere in the stack, naming offending logical IDs. This is what stops a new route from silently reintroducing the 30 resources.
- `cdk/test/main.test.ts` — new `buildApp — CloudFormation template-body budget (#852)` block, reading the emitted artifact (not `Template.fromStack`, which has already parsed indentation away). Asserts the template carries no indentation and stays under 800,000 bytes — the same 80% point at which CDK starts warning, so a regression trips here instead of riding the warning band up to the hard limit.

#### Not in scope

- **`defaultCorsPreflightOptions`** (`task-api.ts`) is left exactly as it was. Dropping it would free a further 34 resources, but unlike the two changes here it alters the API contract, so it is a product decision. It is held in reserve as a contingency of roughly the same size as this whole PR.
- **API Gateway permission method-scoping** still has no test asserting it. #852 records that the suite passes with every `SourceArn` widened to a wildcard. Adding that guard is a separate change; this PR does not widen any `SourceArn`.
- **A `@aws-cdk/core:stackResourceLimit` context budget.** The built-in key already exists and is unset; wiring it is worth doing, but it applies one number to all stacks including nested ones, so it needs its own discussion.

#### Governance

✅ **Cleared under [ADR-003](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/blob/main/docs/decisions/ADR-003-contribution-governance.md).** #852 now carries `approved` + `P0` and is assigned; this PR is out of draft. (Superseded note: this section previously read that #852 lacked the `approved` label and an assignee, which was true when the PR was opened as a draft and is no longer.)

⚠️ **Branch name still non-conforming.** `fix/resource-byte-headroom` omits the issue number `AGENTS.md` requires (`(feat|fix|chore|docs)/<issue-number>-short-description`). Nothing rejects it today — `scripts/hooks/check-branch-name.mjs` lands with #679, still **open** as of 2026-09-03 — but it would be rejected once that merges. GitHub cannot re-point an open PR's head ref, so correcting this means close-and-reopen rather than a rename; not doing that unilaterally to an approved, mergeable PR. Raised in review by @ayushtr-aws and recorded on [#852](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/issues/852#issuecomment-5531387755).

⬜ **Review nits deferred, not dropped.** @ayushtr-aws approved with 7 non-blocking nits; all are transcribed on [#852](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/issues/852#issuecomment-5531387755) for follow-up PRs. None affects the deployed template — they concern the guards this PR adds over-claiming their coverage (notably `RegistryApi extends NestedStack`, so its 4 `LambdaIntegration` sites are outside the `test-invoke-stage` assertion).

#### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/sample-autonomous-cloud-coding-agents/blob/main/LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

